### PR TITLE
fix: Ensure owning segment matches to parent segment from rule or condition

### DIFF
--- a/common/segments/serializers.py
+++ b/common/segments/serializers.py
@@ -256,7 +256,7 @@ class SegmentSerializer(serializers.ModelSerializer, SerializerWithMetadata):
 
     @staticmethod
     def _update_or_create_conditions(
-        conditions_data: dict,
+        conditions_data: dict[str, Any],
         rule: models.Model,
         segment: models.Model | None = None,
         is_create: bool = False,


### PR DESCRIPTION
## Changes

Fixes https://github.com/Flagsmith/flagsmith/issues/4399

Presently the rules and conditions associated with a segment are not enforced to match the segment that they're included in. This PR enforces that the segments match by throwing a validation error.

## Testing

Tests were done in the main repo in [this PR](https://github.com/Flagsmith/flagsmith/pull/4776).