### PR TITLE
fix: segment limit validation versioning

### DIFF
--- a/common/segments/serializers.py
+++ b/common/segments/serializers.py
@@ -120,7 +120,12 @@ class SegmentSerializer(serializers.ModelSerializer, SerializerWithMetadata):
         return response
 
     def validate_project_segment_limit(self, project: models.Model) -> None:
-        if project.segments.count() >= project.max_segments_allowed:
+        if (
+            apps.get_model("segments", "Segment")
+            .objects.filter(project=project)
+            .count()
+            >= project.max_segments_allowed
+        ):
             raise ValidationError(
                 {
                     "project": "The project has reached the maximum allowed segments limit."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flagsmith_common"
-version = "0.1.0"
+version = "1.4.1"
 description = "A repository for including code that is required in multiple flagsmith repositories"
 authors = ["Matthew Elwell <matthew.elwell@flagsmith.com>"]
 readme = "README.md"


### PR DESCRIPTION
Fixes segment limit validation by excluding old segment versions. 

Note that this will be tested [here](https://github.com/Flagsmith/flagsmith/pull/4886)