### PR TITLE
fix: segment limit validation versioning

### DIFF
--- a/common/segments/serializers.py
+++ b/common/segments/serializers.py
@@ -122,7 +122,7 @@ class SegmentSerializer(serializers.ModelSerializer, SerializerWithMetadata):
     def validate_project_segment_limit(self, project: models.Model) -> None:
         if (
             apps.get_model("segments", "Segment")
-            .objects.filter(project=project)
+            .live_objects.filter(project=project)
             .count()
             >= project.max_segments_allowed
         ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flagsmith_common"
-version = "1.4.1"
+version = "1.4.2"
 description = "A repository for including code that is required in multiple flagsmith repositories"
 authors = ["Matthew Elwell <matthew.elwell@flagsmith.com>"]
 readme = "README.md"


### PR DESCRIPTION
This updates the queryset to only use live_objects