### PR TITLE
feat: Provide documented routes as labels

### DIFF
--- a/src/common/gunicorn/middleware.py
+++ b/src/common/gunicorn/middleware.py
@@ -3,6 +3,7 @@ from typing import Callable
 from django.http import HttpRequest, HttpResponse
 
 from common.gunicorn.constants import WSGI_DJANGO_ROUTE_ENVIRON_KEY
+from common.gunicorn.utils import get_route_template
 
 
 class RouteLoggerMiddleware:
@@ -23,6 +24,8 @@ class RouteLoggerMiddleware:
         if resolver_match := request.resolver_match:
             # https://peps.python.org/pep-3333/#specification-details
             # "...the application is allowed to modify the dictionary in any way it desires"
-            request.META[WSGI_DJANGO_ROUTE_ENVIRON_KEY] = resolver_match.route
+            request.META[WSGI_DJANGO_ROUTE_ENVIRON_KEY] = get_route_template(
+                resolver_match.route
+            )
 
         return response

--- a/src/common/gunicorn/utils.py
+++ b/src/common/gunicorn/utils.py
@@ -1,9 +1,11 @@
 import argparse
 import os
+from functools import lru_cache
 from typing import Any
 
 from django.core.handlers.wsgi import WSGIHandler
 from django.core.wsgi import get_wsgi_application
+from drf_yasg.generators import EndpointEnumerator  # type: ignore[import-untyped]
 from environs import Env
 from gunicorn.app.wsgiapp import (  # type: ignore[import-untyped]
     WSGIApplication as GunicornWSGIApplication,
@@ -59,3 +61,18 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
 
 def run_server(options: dict[str, Any] | None = None) -> None:
     DjangoWSGIApplication(options).run()
+
+
+@lru_cache
+def get_route_template(route: str) -> str:
+    """
+    Convert a Django regex route to a template string that can be
+    searched for in the API documentation.
+
+    e.g.,
+
+    `"^api/v1/environments/(?P<environment_api_key>[^/.]+)/api-keys/$"` ->
+    `"api/v1/environments/{environment_api_key}/api-keys/"`
+    """
+    route_template: str = EndpointEnumerator().get_path_from_regex(route)
+    return route_template

--- a/src/common/gunicorn/utils.py
+++ b/src/common/gunicorn/utils.py
@@ -72,7 +72,7 @@ def get_route_template(route: str) -> str:
     e.g.,
 
     `"^api/v1/environments/(?P<environment_api_key>[^/.]+)/api-keys/$"` ->
-    `"api/v1/environments/{environment_api_key}/api-keys/"`
+    `"/api/v1/environments/{environment_api_key}/api-keys/"`
     """
     route_template: str = EndpointEnumerator().get_path_from_regex(route)
     return route_template


### PR DESCRIPTION
This PR adds an extra step when logging Django routes to produce label values identical to Flagsmith's public OpenAPI spec. This produces consistent, human-readable and searchable label values:

<img width="725" alt="image" src="https://github.com/user-attachments/assets/00efb7a6-18d6-40c2-b3ad-c59bbbab583c" />


