### PR TITLE
feat(test-tools): SaaS/Enterprise mode markers, update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,56 @@ make install-packages opts="--extras 'feature1 feature2'"
 
 #### Installation
 
-1. Make sure `"common.core"` is in the `INSTALLED_APPS` of your settings module.
+1. To make use of the `test_tools` Pytest plugin, install the packages with the `test-tools` extra, e.g. `pip install flagsmith-common[test-tools]`.
+
+2. Make sure `"common.core"` is in the `INSTALLED_APPS` of your settings module.
 This enables the `manage.py flagsmith` commands.
 
-2. Add `"common.gunicorn.middleware.RouteLoggerMiddleware"` to `MIDDLEWARE` in your settings module.
+3. Add `"common.gunicorn.middleware.RouteLoggerMiddleware"` to `MIDDLEWARE` in your settings module.
 This enables the `route` label for Prometheus HTTP metrics.
 
-3. To enable the `/metrics` endpoint, set the `PROMETHEUS_ENABLED` setting to `True`.
+4. To enable the `/metrics` endpoint, set the `PROMETHEUS_ENABLED` setting to `True`.
+
+#### Test tools
+
+##### Fixtures
+
+###### `assert_metric`
+
+To test your metrics using the `assert_metric` fixture:
+
+```python
+from common.test_tools import AssertMetricFixture
+
+def test_my_code__expected_metrics(assert_metric: AssertMetricFixture) -> None:
+    # When
+    my_code()
+
+    # Then
+    assert_metric(
+        name="flagsmith_distance_from_earth_au_sum",
+        labels={"engine_type": "solar_sail"},
+        value=1.0,
+    )
+```
+
+###### `saas_mode`
+
+The `saas_mode` fixture makes all `common.core.utils.is_saas` calls return `True`.
+
+###### `enterprise_mode`
+
+The `enterprise_mode` fixture makes all `common.core.utils.is_enterprise` calls return `True`.
+
+##### Markers
+
+###### `pytest.mark.saas_mode`
+
+Use this mark to auto-use the `saas_mode` fixture.
+
+###### `pytest.mark.enterprise_mode`
+
+Use this mark to auto-use the `enterprise_mode` fixture.
 
 #### Metrics
 
@@ -87,14 +130,18 @@ It's generally a good idea to allow users to define histogram buckets of their o
 import prometheus_client
 from django.conf import settings
 
-flagsmith_distance_from_earth_au = prometheus.Histogram(
+flagsmith_distance_from_earth_au = prometheus_client.Histogram(
     "flagsmith_distance_from_earth_au",
     "Distance from Earth in astronomical units",
+    labels=["engine_type"],
     buckets=settings.DISTANCE_FROM_EARTH_AU_HISTOGRAM_BUCKETS,
 )
 ```
+
+For testing your metrics, refer to [`assert_metric` documentation][5].
 
 [1]: https://prometheus.io/docs/practices/naming/
 [2]: https://github.com/Flagsmith/flagsmith-common/blob/main/src/common/gunicorn/metrics.py
 [3]: https://docs.gunicorn.org/en/stable/design.html#server-model
 [4]: https://prometheus.github.io/client_python/multiprocess
+[5]: #assert_metric

--- a/poetry.lock
+++ b/poetry.lock
@@ -171,7 +171,7 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
@@ -592,7 +592,7 @@ version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
@@ -730,7 +730,7 @@ version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
     {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
@@ -1011,7 +1011,7 @@ version = "8.3.4"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
     {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
@@ -1105,7 +1105,7 @@ version = "3.14.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
     {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
@@ -1568,7 +1568,10 @@ platformdirs = ">=3.9.1,<5"
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8) ; platform_python_implementation == \"PyPy\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\" and python_version >= \"3.13\"", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10) ; platform_python_implementation == \"CPython\""]
 
+[extras]
+test-tools = ["pytest-mock"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "947b4e34fce30980f39cfc2ca1090bcbb4a89a5725647c9ce83df15719d2119d"
+content-hash = "ca00d2930fdc7781ce068499cc3e01e461678f0bf04d17c2bd457d0aefcddd2f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "psycopg2-binary (>=2.9,<3)",
     "simplejson (>=3,<4)",
 ]
+optional-dependencies = { test-tools = ["pytest-mock (>=3,<4)"] }
 authors = [
     { name = "Matthew Elwell" },
     { name = "Gagan Trivedi" },

--- a/src/common/test_tools/plugin.py
+++ b/src/common/test_tools/plugin.py
@@ -3,6 +3,7 @@ from typing import Generator
 import prometheus_client
 import pytest
 from prometheus_client.metrics import MetricWrapperBase
+from pytest_mock import MockerFixture
 
 from common.test_tools.types import AssertMetricFixture
 
@@ -32,3 +33,22 @@ def assert_metric_impl() -> Generator[AssertMetricFixture, None, None]:
 
 
 assert_metric = pytest.fixture(assert_metric_impl)
+
+
+@pytest.fixture()
+def saas_mode(mocker: MockerFixture) -> None:
+    mocker.patch("common.core.utils.is_saas", return_value=True)
+
+
+@pytest.fixture()
+def enterprise_mode(mocker: MockerFixture) -> None:
+    mocker.patch("common.core.utils.is_enterprise", return_value=True)
+
+
+@pytest.fixture(autouse=True)
+def flagsmith_markers_marked(request: pytest.FixtureRequest) -> None:
+    for marker in request.node.iter_markers():
+        if marker.name == "saas_mode":
+            request.getfixturevalue("saas_mode")
+        if marker.name == "enterprise_mode":
+            request.getfixturevalue("enterprise_mode")

--- a/tests/unit/common/test_tools/test_plugin.py
+++ b/tests/unit/common/test_tools/test_plugin.py
@@ -37,3 +37,21 @@ def test_assert_metrics__registry_reset_expected(
             labels={"test_name": "test_assert_metrics__registry_reset_expected"},
             value=1,
         )
+
+
+@pytest.mark.saas_mode
+def test_saas_mode_marker__is_saas_returns_expected() -> None:
+    # Given
+    from common.core.utils import is_saas
+
+    # When & Then
+    assert is_saas() is True
+
+
+@pytest.mark.enterprise_mode
+def test_enterprise_mode_marker__is_enterprise_returns_expected() -> None:
+    # Given
+    from common.core.utils import is_enterprise
+
+    # When & Then
+    assert is_enterprise() is True


### PR DESCRIPTION
Embracing the spreading usage of `common.core.utils.is_saas` and `common.core.utils.is_enterprise` utility functions, I'm adding convenient shortcuts for testing code that depends on them.

`test-tools` now depend on `pytest_mock` so I've added an optional dependency group to reflect that.

Additionally, documentation is updated to reflect all testing tools we have.