### PR TITLE
feat: Ability to log WSGI `environ` in JSON logs, `log_extra` utility

### DIFF
--- a/src/common/gunicorn/constants.py
+++ b/src/common/gunicorn/constants.py
@@ -1,4 +1,3 @@
-WSGI_DJANGO_ROUTE_ENVIRON_KEY = "django.route"
 WSGI_EXTRA_PREFIX = "flagsmith."
 WSGI_EXTRA_SUFFIX_TO_CATEGORY = {
     "i": "request_headers",

--- a/src/common/gunicorn/constants.py
+++ b/src/common/gunicorn/constants.py
@@ -1,4 +1,10 @@
-WSGI_DJANGO_ROUTE_ENVIRON_KEY = "wsgi.django_route"
+WSGI_DJANGO_ROUTE_ENVIRON_KEY = "django.route"
+WSGI_EXTRA_PREFIX = "flagsmith."
+WSGI_EXTRA_SUFFIX_TO_CATEGORY = {
+    "i": "request_headers",
+    "o": "response_headers",
+    "e": "environ_variables",
+}
 HTTP_SERVER_RESPONSE_SIZE_DEFAULT_BUCKETS = (
     # 1 kB, 10 kB, 100 kB, 500 kB, 1 MB, 5 MB, 10 MB
     1 * 1024,

--- a/src/common/gunicorn/middleware.py
+++ b/src/common/gunicorn/middleware.py
@@ -2,8 +2,7 @@ from typing import Callable
 
 from django.http import HttpRequest, HttpResponse
 
-from common.gunicorn.constants import WSGI_DJANGO_ROUTE_ENVIRON_KEY
-from common.gunicorn.utils import get_route_template
+from common.gunicorn.utils import get_route_template, log_extra
 
 
 class RouteLoggerMiddleware:
@@ -22,10 +21,10 @@ class RouteLoggerMiddleware:
         response = self.get_response(request)
 
         if resolver_match := request.resolver_match:
-            # https://peps.python.org/pep-3333/#specification-details
-            # "...the application is allowed to modify the dictionary in any way it desires"
-            request.META[WSGI_DJANGO_ROUTE_ENVIRON_KEY] = get_route_template(
-                resolver_match.route
+            log_extra(
+                request=request,
+                key="route",
+                value=get_route_template(resolver_match.route),
             )
 
         return response

--- a/src/common/gunicorn/utils.py
+++ b/src/common/gunicorn/utils.py
@@ -5,12 +5,15 @@ from typing import Any
 
 from django.core.handlers.wsgi import WSGIHandler
 from django.core.wsgi import get_wsgi_application
+from django.http import HttpRequest
 from drf_yasg.generators import EndpointEnumerator  # type: ignore[import-untyped]
 from environs import Env
 from gunicorn.app.wsgiapp import (  # type: ignore[import-untyped]
     WSGIApplication as GunicornWSGIApplication,
 )
 from gunicorn.config import Config  # type: ignore[import-untyped]
+
+from common.gunicorn.constants import WSGI_EXTRA_PREFIX
 
 env = Env()
 
@@ -76,3 +79,12 @@ def get_route_template(route: str) -> str:
     """
     route_template: str = EndpointEnumerator().get_path_from_regex(route)
     return route_template
+
+
+def log_extra(
+    request: HttpRequest,
+    key: str,
+    value: str | int | float,
+) -> None:
+    meta_key = f"{WSGI_EXTRA_PREFIX}{key}"
+    request.META[meta_key] = value

--- a/src/common/gunicorn/utils.py
+++ b/src/common/gunicorn/utils.py
@@ -84,7 +84,21 @@ def get_route_template(route: str) -> str:
 def log_extra(
     request: HttpRequest,
     key: str,
-    value: str | int | float,
+    value: Any,
 ) -> None:
+    """
+    Store a value in the WSGI request `environ` using a prefixed key.
+
+    https://peps.python.org/pep-3333/#specification-details
+    "...the application is allowed to modify the dictionary in any way it desires"
+    """
     meta_key = f"{WSGI_EXTRA_PREFIX}{key}"
     request.META[meta_key] = value
+
+
+def get_extra(environ: dict[str, Any], key: str) -> Any:
+    """
+    Retrieve a value from the WSGI request `environ` using a prefixed key.
+    """
+    meta_key = f"{WSGI_EXTRA_PREFIX}{key}"
+    return environ.get(meta_key)

--- a/tests/unit/common/gunicorn/test_logging.py
+++ b/tests/unit/common/gunicorn/test_logging.py
@@ -22,7 +22,7 @@ def test_gunicorn_access_log_json_formatter__outputs_expected(
 ) -> None:
     # Given
     settings.ACCESS_LOG_JSON_EXTRA_ITEMS = [
-        "{django.route}e",
+        "{flagsmith.route}e",
         "{X-LOG-ME-STATUS}o",
         "{x-log-me}i",
     ]
@@ -35,7 +35,7 @@ def test_gunicorn_access_log_json_formatter__outputs_expected(
         lineno=1,
         msg=AccessLogFormat.default,
         args={
-            "{django.route}e": "/test/{test_id}",
+            "{flagsmith.route}e": "/test/{test_id}",
             "{wsgi.version}e": (1, 0),
             "{x-log-me-status}o": "acked",
             "{x-log-me}i": "42",
@@ -72,7 +72,7 @@ def test_gunicorn_access_log_json_formatter__outputs_expected(
     assert json_log == {
         "duration_in_ms": 1000,
         "environ_variables": {
-            "django.route": "/test/{test_id}",
+            "flagsmith.route": "/test/{test_id}",
         },
         "levelname": "INFO",
         "logger_name": "gunicorn.access",
@@ -114,7 +114,7 @@ def test_gunicorn_prometheus_gunicorn_logger__expected_metrics(
     logger.access(
         response_mock,
         mocker.Mock(),
-        {"django.route": "/health", "REQUEST_METHOD": "GET"},
+        {"flagsmith.route": "/health", "REQUEST_METHOD": "GET"},
         timedelta(milliseconds=101),
     )
 

--- a/tests/unit/common/gunicorn/test_logging.py
+++ b/tests/unit/common/gunicorn/test_logging.py
@@ -17,8 +17,16 @@ from common.test_tools import AssertMetricFixture
 
 
 @pytest.mark.freeze_time("2023-12-08T06:05:47.320000+00:00")
-def test_gunicorn_access_log_json_formatter__outputs_expected() -> None:
+def test_gunicorn_access_log_json_formatter__outputs_expected(
+    settings: SettingsWrapper,
+) -> None:
     # Given
+    settings.ACCESS_LOG_JSON_EXTRA_ITEMS = [
+        "{django.route}e",
+        "{X-LOG-ME-STATUS}o",
+        "{x-log-me}i",
+    ]
+
     gunicorn_access_log_json_formatter = GunicornAccessLogJsonFormatter()
     log_record = logging.LogRecord(
         name="gunicorn.access",
@@ -27,9 +35,13 @@ def test_gunicorn_access_log_json_formatter__outputs_expected() -> None:
         lineno=1,
         msg=AccessLogFormat.default,
         args={
+            "{django.route}e": "/test/{test_id}",
+            "{wsgi.version}e": (1, 0),
+            "{x-log-me-status}o": "acked",
+            "{x-log-me}i": "42",
             "a": "requests",
-            "b": "-",
-            "B": None,
+            "b": 42,
+            "B": 42,
             "D": 1000000,
             "f": "-",
             "h": "192.168.0.1",
@@ -40,7 +52,6 @@ def test_gunicorn_access_log_json_formatter__outputs_expected() -> None:
             "M": 1000,
             "p": "<42>",
             "q": "foo=bar",
-            "R": "^test/",
             "r": "GET",
             "s": 200,
             "T": 1,
@@ -48,7 +59,7 @@ def test_gunicorn_access_log_json_formatter__outputs_expected() -> None:
                 "[%d/%b/%Y:%H:%M:%S %z]"
             ),
             "u": "-",
-            "U": "/test",
+            "U": "/test/42",
         },
         exc_info=None,
     )
@@ -60,14 +71,24 @@ def test_gunicorn_access_log_json_formatter__outputs_expected() -> None:
     # Then
     assert json_log == {
         "duration_in_ms": 1000,
+        "environ_variables": {
+            "django.route": "/test/{test_id}",
+        },
         "levelname": "INFO",
         "logger_name": "gunicorn.access",
-        "message": '192.168.0.1 - - [08/Dec/2023:06:05:47 +0000] "GET" 200 - "-" "requests"',
+        "message": '192.168.0.1 - - [08/Dec/2023:06:05:47 +0000] "GET" 200 42 "-" "requests"',
         "method": "GET",
-        "path": "/test?foo=bar",
+        "path": "/test/42?foo=bar",
         "pid": expected_pid,
         "remote_ip": "192.168.0.1",
-        "route": "^test/",
+        "request_headers": {
+            "x-log-me": "42",
+        },
+        "response_headers": {
+            "x-log-me-status": "acked",
+        },
+        "response_size_in_bytes": 42,
+        "route": "/test/{test_id}",
         "status": "200",
         "thread_name": "MainThread",
         "time": "2023-12-08T06:05:47+00:00",
@@ -87,13 +108,13 @@ def test_gunicorn_prometheus_gunicorn_logger__expected_metrics(
     response_mock = mocker.Mock()
     response_mock.status = b"200 OK"
     response_mock.status_code = 200
-    response_mock.response_length = 42
+    response_mock.sent = 42
 
     # When
     logger.access(
         response_mock,
         mocker.Mock(),
-        {"wsgi.django_route": "/health", "REQUEST_METHOD": "GET"},
+        {"django.route": "/health", "REQUEST_METHOD": "GET"},
         timedelta(milliseconds=101),
     )
 


### PR DESCRIPTION
This PR capitalises on Gunicorn's existing [ability]() to log request/response headers and [WSGI environ keys](https://wsgi.readthedocs.io/en/latest/definitions.html), enabling our JSON access log formatter to log these as well.

Flagsmith will now accept an `ACCESS_LOG_JSON_EXTRA_ITEMS` setting, consisting of [Gunicorn atom keys](https://docs.gunicorn.org/en/stable/settings.html#access-log-format), e.g.:

- `{x-environment-key}i`: the `X-Environment-Key` request header...
- ...`{content-type}o`: the `Content-Type` response header...
- ...`{wsgi.version}e`: the `wsgi.version` WSGI environ value...

...in line with the `ACCESS_LOG_FORMAT` setting we employ for rendering the non-JSON access logs.

The PR also exposes the `common.gunicorn.utils.log_extra` utility function which is a shortcut to logging the extra values as WSGI environ keys with the `flagsmith.` prefix. The custom key used for logging routes has been updated to match this convention.

This is part 1 of an effort to enable logging environment keys in access logs for a major customer.