### PR TITLE
feat: Deliver the deployed API version to an HTTP response header

### DIFF
--- a/src/common/core/middleware.py
+++ b/src/common/core/middleware.py
@@ -24,7 +24,4 @@ class APIResponseVersionHeaderMiddleware:
     def get_version(self) -> str | None:
         """Obtains the version number from the manifest file"""
         manifest_versions = get_versions_from_manifest()
-        if not manifest_versions:
-            return None
-        version: str | None = manifest_versions.get(".")
-        return version
+        return manifest_versions["."]

--- a/src/common/core/middleware.py
+++ b/src/common/core/middleware.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 from django.http import HttpRequest, HttpResponse
 
-from common.core.utils import get_versions_from_manifest
+from common.core.utils import UNKNOWN, get_versions_from_manifest
 
 
 class APIResponseVersionHeaderMiddleware:
@@ -18,10 +18,11 @@ class APIResponseVersionHeaderMiddleware:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         response = self.get_response(request)
-        response.headers["X-Flagsmith-Version"] = self.get_version() or "unknown"
+        response.headers["X-Flagsmith-Version"] = self.get_version()
         return response
     
-    def get_version(self) -> str | None:
+    def get_version(self) -> str:
         """Obtains the version number from the manifest file"""
         manifest_versions = get_versions_from_manifest()
-        return manifest_versions["."]
+        version: str = manifest_versions.get(".") or UNKNOWN
+        return version

--- a/src/common/core/middleware.py
+++ b/src/common/core/middleware.py
@@ -1,0 +1,30 @@
+from typing import Callable
+
+from django.http import HttpRequest, HttpResponse
+
+from common.core.utils import get_versions_from_manifest
+
+
+class APIResponseVersionHeaderMiddleware:
+    """
+    Middleware to add the API version to the response headers
+    """
+
+    def __init__(
+        self,
+        get_response: Callable[[HttpRequest], HttpResponse],
+    ) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        response = self.get_response(request)
+        response.headers["X-Flagsmith-Version"] = self.get_version() or "unknown"
+        return response
+    
+    def get_version(self) -> str | None:
+        """Obtains the version number from the manifest file"""
+        manifest_versions = get_versions_from_manifest()
+        if not manifest_versions:
+            return None
+        version: str | None = manifest_versions.get(".")
+        return version

--- a/src/common/core/middleware.py
+++ b/src/common/core/middleware.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 from django.http import HttpRequest, HttpResponse
 
-from common.core.utils import get_version_number
+from common.core.utils import get_version
 
 
 class APIResponseVersionHeaderMiddleware:
@@ -18,5 +18,5 @@ class APIResponseVersionHeaderMiddleware:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         response = self.get_response(request)
-        response.headers["Flagsmith-Version"] = get_version_number()
+        response.headers["Flagsmith-Version"] = get_version()
         return response

--- a/src/common/core/middleware.py
+++ b/src/common/core/middleware.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 from django.http import HttpRequest, HttpResponse
 
-from common.core.utils import UNKNOWN, get_versions_from_manifest
+from common.core.utils import get_version_number
 
 
 class APIResponseVersionHeaderMiddleware:
@@ -18,11 +18,5 @@ class APIResponseVersionHeaderMiddleware:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         response = self.get_response(request)
-        response.headers["Flagsmith-Version"] = self.get_version()
+        response.headers["Flagsmith-Version"] = get_version_number()
         return response
-
-    def get_version(self) -> str:
-        """Obtains the version number from the manifest file"""
-        manifest_versions = get_versions_from_manifest()
-        version: str = manifest_versions.get(".") or UNKNOWN
-        return version

--- a/src/common/core/middleware.py
+++ b/src/common/core/middleware.py
@@ -20,7 +20,7 @@ class APIResponseVersionHeaderMiddleware:
         response = self.get_response(request)
         response.headers["Flagsmith-Version"] = self.get_version()
         return response
-    
+
     def get_version(self) -> str:
         """Obtains the version number from the manifest file"""
         manifest_versions = get_versions_from_manifest()

--- a/src/common/core/middleware.py
+++ b/src/common/core/middleware.py
@@ -18,7 +18,7 @@ class APIResponseVersionHeaderMiddleware:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         response = self.get_response(request)
-        response.headers["X-Flagsmith-Version"] = self.get_version()
+        response.headers["Flagsmith-Version"] = self.get_version()
         return response
     
     def get_version(self) -> str:

--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -90,7 +90,7 @@ def get_version_info() -> VersionInfo:
 
 
 def get_version() -> str:
-    """Returns the version number of the current deployment"""
+    """Return the version number of the current deployment"""
     manifest_versions = get_versions_from_manifest()
     return manifest_versions.get(".", UNKNOWN)
 

--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -17,9 +17,12 @@ class SelfHostedData(TypedDict):
     has_logins: bool
 
 
-VersionManifest = TypedDict("VersionManifest", {
-    ".": str,  # This key is used to store the version of the package itself
-})
+VersionManifest = TypedDict(
+    "VersionManifest",
+    {
+        ".": str,  # This key is used to store the version of the package itself
+    },
+)
 
 
 class VersionInfo(TypedDict):
@@ -92,7 +95,7 @@ def get_versions_from_manifest() -> VersionManifest:
     raw_content = get_file_contents(VERSIONS_INFO_FILE_LOCATION)
     if not raw_content:
         return {".": UNKNOWN}
-    
+
     manifest: VersionManifest = json.loads(raw_content)
     return manifest
 

--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -55,7 +55,7 @@ def has_email_provider() -> bool:
 
 
 def get_version_info() -> VersionInfo:
-    """Reads the version info baked into src folder of the docker container"""
+    """Returns the version information for the current deployment"""
     _is_saas = is_saas()
     version_json: VersionInfo = {
         "ci_commit_sha": get_file_contents("./CI_COMMIT_SHA") or UNKNOWN,
@@ -66,10 +66,8 @@ def get_version_info() -> VersionInfo:
         "self_hosted_data": None,
     }
 
-    manifest_versions_content = get_file_contents(VERSIONS_INFO_FILE_LOCATION)
-
-    if manifest_versions_content:
-        manifest_versions = json.loads(manifest_versions_content)
+    manifest_versions = get_versions_from_manifest()
+    if manifest_versions:
         version_json["package_versions"] = manifest_versions
         version_json["image_tag"] = manifest_versions["."]
 
@@ -82,6 +80,17 @@ def get_version_info() -> VersionInfo:
         }
 
     return version_json
+
+
+@lru_cache()
+def get_versions_from_manifest() -> dict[str, str] | None:
+    """Reads the version info baked into the Docker container"""
+    raw_content = get_file_contents(VERSIONS_INFO_FILE_LOCATION)
+    if not raw_content:
+        return None
+    
+    manifest: dict[str, str] = json.loads(raw_content)
+    return manifest
 
 
 @lru_cache()

--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -89,6 +89,12 @@ def get_version_info() -> VersionInfo:
     return version_json
 
 
+def get_version_number() -> str:
+    """Returns the version number of the current deployment"""
+    manifest_versions = get_versions_from_manifest()
+    return manifest_versions.get(".", UNKNOWN)
+
+
 @lru_cache()
 def get_versions_from_manifest() -> VersionManifest:
     """Reads the version info from the manifest file"""

--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -89,7 +89,7 @@ def get_version_info() -> VersionInfo:
     return version_json
 
 
-def get_version_number() -> str:
+def get_version() -> str:
     """Returns the version number of the current deployment"""
     manifest_versions = get_versions_from_manifest()
     return manifest_versions.get(".", UNKNOWN)

--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -17,6 +17,11 @@ class SelfHostedData(TypedDict):
     has_logins: bool
 
 
+VersionManifest = TypedDict("VersionManifest", {
+    ".": str,  # This key is used to store the version of the package itself
+})
+
+
 class VersionInfo(TypedDict):
     ci_commit_sha: str
     image_tag: str
@@ -24,7 +29,7 @@ class VersionInfo(TypedDict):
     is_enterprise: bool
     is_saas: bool
     self_hosted_data: SelfHostedData | None
-    package_versions: NotRequired[dict[str, str]]
+    package_versions: NotRequired[VersionManifest]
 
 
 @lru_cache()
@@ -67,9 +72,8 @@ def get_version_info() -> VersionInfo:
     }
 
     manifest_versions = get_versions_from_manifest()
-    if manifest_versions:
-        version_json["package_versions"] = manifest_versions
-        version_json["image_tag"] = manifest_versions["."]
+    version_json["package_versions"] = manifest_versions
+    version_json["image_tag"] = manifest_versions["."]
 
     if not _is_saas:
         user_objects: Manager[AbstractBaseUser] = getattr(get_user_model(), "objects")
@@ -83,13 +87,13 @@ def get_version_info() -> VersionInfo:
 
 
 @lru_cache()
-def get_versions_from_manifest() -> dict[str, str] | None:
-    """Reads the version info baked into the Docker container"""
+def get_versions_from_manifest() -> VersionManifest:
+    """Reads the version info from the manifest file"""
     raw_content = get_file_contents(VERSIONS_INFO_FILE_LOCATION)
     if not raw_content:
-        return None
+        return {".": UNKNOWN}
     
-    manifest: dict[str, str] = json.loads(raw_content)
+    manifest: VersionManifest = json.loads(raw_content)
     return manifest
 
 

--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -97,7 +97,7 @@ def get_version() -> str:
 
 @lru_cache()
 def get_versions_from_manifest() -> VersionManifest:
-    """Reads the version info from the manifest file"""
+    """Read the version info from the manifest file"""
     raw_content = get_file_contents(VERSIONS_INFO_FILE_LOCATION)
     if not raw_content:
         return {".": UNKNOWN}

--- a/tests/unit/common/core/test_logging.py
+++ b/tests/unit/common/core/test_logging.py
@@ -44,7 +44,7 @@ def test_json_formatter__outputs_expected(
         {
             "levelname": "INFO",
             "message": "hello arg1, 22",
-            "timestamp": "2023-12-08 06:05:47,320",
+            "timestamp": "2023-12-08 06:05:47,319",
             "logger_name": "test_json_formatter__outputs_expected",
             "pid": expected_pid,
             "thread_name": "MainThread",
@@ -52,7 +52,7 @@ def test_json_formatter__outputs_expected(
         {
             "levelname": "ERROR",
             "message": "this is an error",
-            "timestamp": "2023-12-08 06:05:47,320",
+            "timestamp": "2023-12-08 06:05:47,319",
             "logger_name": "test_json_formatter__outputs_expected",
             "pid": expected_pid,
             "thread_name": "MainThread",

--- a/tests/unit/common/core/test_logging.py
+++ b/tests/unit/common/core/test_logging.py
@@ -44,7 +44,7 @@ def test_json_formatter__outputs_expected(
         {
             "levelname": "INFO",
             "message": "hello arg1, 22",
-            "timestamp": "2023-12-08 06:05:47,319",
+            "timestamp": "2023-12-08 06:05:47,320",
             "logger_name": "test_json_formatter__outputs_expected",
             "pid": expected_pid,
             "thread_name": "MainThread",
@@ -52,7 +52,7 @@ def test_json_formatter__outputs_expected(
         {
             "levelname": "ERROR",
             "message": "this is an error",
-            "timestamp": "2023-12-08 06:05:47,319",
+            "timestamp": "2023-12-08 06:05:47,320",
             "logger_name": "test_json_formatter__outputs_expected",
             "pid": expected_pid,
             "thread_name": "MainThread",

--- a/tests/unit/common/core/test_middleware.py
+++ b/tests/unit/common/core/test_middleware.py
@@ -1,0 +1,55 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from common.core import middleware as middleware_module
+
+
+def test_APIResponseVersionHeaderMiddleware__valid_version_info___adds_version_header(
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    request = mocker.Mock()
+    response = mocker.Mock(headers={})
+    get_response = mocker.Mock(return_value=response)
+    middleware = middleware_module.APIResponseVersionHeaderMiddleware(get_response)
+    get_versions_from_manifest = mocker.patch.object(
+        middleware_module, "get_versions_from_manifest",
+        return_value={".": "v1.2.3"},
+    )
+
+    # When
+    result = middleware(request)
+
+    # Then
+    assert result == response
+    assert response.headers["X-Flagsmith-Version"] == "v1.2.3"
+    assert get_response.call_args_list == [mocker.call(request)]
+    assert get_versions_from_manifest.call_args_list == [mocker.call()]
+
+
+@pytest.mark.parametrize("version_info", [
+    {},
+    None,
+])
+def test_APIResponseVersionHeaderMiddleware__invalid_version_info___adds_unknown_header(
+    mocker: MockerFixture,
+    version_info: dict[str, str] | None,
+) -> None:
+    # Given
+    request = mocker.Mock()
+    response = mocker.Mock(headers={})
+    get_response = mocker.Mock(return_value=response)
+    middleware = middleware_module.APIResponseVersionHeaderMiddleware(get_response)
+    get_versions_from_manifest = mocker.patch.object(
+        middleware_module, "get_versions_from_manifest",
+        return_value=version_info,
+    )
+
+    # When
+    result = middleware(request)
+
+    # Then
+    assert result == response
+    assert response.headers["X-Flagsmith-Version"] == "unknown"
+    assert get_response.call_args_list == [mocker.call(request)]
+    assert get_versions_from_manifest.call_args_list == [mocker.call()]

--- a/tests/unit/common/core/test_middleware.py
+++ b/tests/unit/common/core/test_middleware.py
@@ -1,17 +1,9 @@
-import pytest
 from pytest_mock import MockerFixture
 
 from common.core import middleware as middleware_module
-from common.core import utils
 
 
-@pytest.fixture(autouse=True)
-def clear_lru_caches() -> None:
-    utils.get_file_contents.cache_clear()
-    utils.get_versions_from_manifest.cache_clear()
-
-
-def test_APIResponseVersionHeaderMiddleware__valid_version_info___adds_version_header(
+def test_APIResponseVersionHeaderMiddleware__adds_version_header(
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -19,10 +11,10 @@ def test_APIResponseVersionHeaderMiddleware__valid_version_info___adds_version_h
     response = mocker.Mock(headers={})
     get_response = mocker.Mock(return_value=response)
     middleware = middleware_module.APIResponseVersionHeaderMiddleware(get_response)
-    get_versions_from_manifest = mocker.patch.object(
+    get_version_number = mocker.patch.object(
         middleware_module,
-        "get_versions_from_manifest",
-        return_value={".": "v1.2.3"},
+        "get_version_number",
+        return_value="v1.2.3",
     )
 
     # When
@@ -32,36 +24,4 @@ def test_APIResponseVersionHeaderMiddleware__valid_version_info___adds_version_h
     assert result == response
     assert response.headers["Flagsmith-Version"] == "v1.2.3"
     get_response.assert_called_once_with(request)
-    get_versions_from_manifest.assert_called_once_with()
-
-
-@pytest.mark.parametrize(
-    "version_info",
-    [
-        {"foo": "bar"},
-        {},
-    ],
-)
-def test_APIResponseVersionHeaderMiddleware__invalid_version_info___adds_unknown_header(
-    mocker: MockerFixture,
-    version_info: dict[str, str] | None,
-) -> None:
-    # Given
-    request = mocker.Mock()
-    response = mocker.Mock(headers={})
-    get_response = mocker.Mock(return_value=response)
-    middleware = middleware_module.APIResponseVersionHeaderMiddleware(get_response)
-    get_versions_from_manifest = mocker.patch.object(
-        middleware_module,
-        "get_versions_from_manifest",
-        return_value=version_info,
-    )
-
-    # When
-    result = middleware(request)
-
-    # Then
-    assert result == response
-    assert response.headers["Flagsmith-Version"] == "unknown"
-    get_response.assert_called_once_with(request)
-    get_versions_from_manifest.assert_called_once_with()
+    get_version_number.assert_called_once_with()

--- a/tests/unit/common/core/test_middleware.py
+++ b/tests/unit/common/core/test_middleware.py
@@ -1,7 +1,13 @@
 import pytest
 from pytest_mock import MockerFixture
 
-from common.core import middleware as middleware_module
+from common.core import middleware as middleware_module, utils
+
+
+@pytest.fixture(autouse=True)
+def clear_lru_caches() -> None:
+    utils.get_file_contents.cache_clear()
+    utils.get_versions_from_manifest.cache_clear()
 
 
 def test_APIResponseVersionHeaderMiddleware__valid_version_info___adds_version_header(
@@ -28,8 +34,8 @@ def test_APIResponseVersionHeaderMiddleware__valid_version_info___adds_version_h
 
 
 @pytest.mark.parametrize("version_info", [
+    {"foo": "bar"},
     {},
-    None,
 ])
 def test_APIResponseVersionHeaderMiddleware__invalid_version_info___adds_unknown_header(
     mocker: MockerFixture,

--- a/tests/unit/common/core/test_middleware.py
+++ b/tests/unit/common/core/test_middleware.py
@@ -11,9 +11,9 @@ def test_APIResponseVersionHeaderMiddleware__adds_version_header(
     response = mocker.Mock(headers={})
     get_response = mocker.Mock(return_value=response)
     middleware = middleware_module.APIResponseVersionHeaderMiddleware(get_response)
-    get_version_number = mocker.patch.object(
+    get_version = mocker.patch.object(
         middleware_module,
-        "get_version_number",
+        "get_version",
         return_value="v1.2.3",
     )
 
@@ -24,4 +24,4 @@ def test_APIResponseVersionHeaderMiddleware__adds_version_header(
     assert result == response
     assert response.headers["Flagsmith-Version"] == "v1.2.3"
     get_response.assert_called_once_with(request)
-    get_version_number.assert_called_once_with()
+    get_version.assert_called_once_with()

--- a/tests/unit/common/core/test_middleware.py
+++ b/tests/unit/common/core/test_middleware.py
@@ -28,7 +28,7 @@ def test_APIResponseVersionHeaderMiddleware__valid_version_info___adds_version_h
 
     # Then
     assert result == response
-    assert response.headers["X-Flagsmith-Version"] == "v1.2.3"
+    assert response.headers["Flagsmith-Version"] == "v1.2.3"
     assert get_response.call_args_list == [mocker.call(request)]
     assert get_versions_from_manifest.call_args_list == [mocker.call()]
 
@@ -56,6 +56,6 @@ def test_APIResponseVersionHeaderMiddleware__invalid_version_info___adds_unknown
 
     # Then
     assert result == response
-    assert response.headers["X-Flagsmith-Version"] == "unknown"
+    assert response.headers["Flagsmith-Version"] == "unknown"
     assert get_response.call_args_list == [mocker.call(request)]
     assert get_versions_from_manifest.call_args_list == [mocker.call()]

--- a/tests/unit/common/core/test_middleware.py
+++ b/tests/unit/common/core/test_middleware.py
@@ -1,7 +1,8 @@
 import pytest
 from pytest_mock import MockerFixture
 
-from common.core import middleware as middleware_module, utils
+from common.core import middleware as middleware_module
+from common.core import utils
 
 
 @pytest.fixture(autouse=True)
@@ -19,7 +20,8 @@ def test_APIResponseVersionHeaderMiddleware__valid_version_info___adds_version_h
     get_response = mocker.Mock(return_value=response)
     middleware = middleware_module.APIResponseVersionHeaderMiddleware(get_response)
     get_versions_from_manifest = mocker.patch.object(
-        middleware_module, "get_versions_from_manifest",
+        middleware_module,
+        "get_versions_from_manifest",
         return_value={".": "v1.2.3"},
     )
 
@@ -33,10 +35,13 @@ def test_APIResponseVersionHeaderMiddleware__valid_version_info___adds_version_h
     get_versions_from_manifest.assert_called_once_with()
 
 
-@pytest.mark.parametrize("version_info", [
-    {"foo": "bar"},
-    {},
-])
+@pytest.mark.parametrize(
+    "version_info",
+    [
+        {"foo": "bar"},
+        {},
+    ],
+)
 def test_APIResponseVersionHeaderMiddleware__invalid_version_info___adds_unknown_header(
     mocker: MockerFixture,
     version_info: dict[str, str] | None,
@@ -47,7 +52,8 @@ def test_APIResponseVersionHeaderMiddleware__invalid_version_info___adds_unknown
     get_response = mocker.Mock(return_value=response)
     middleware = middleware_module.APIResponseVersionHeaderMiddleware(get_response)
     get_versions_from_manifest = mocker.patch.object(
-        middleware_module, "get_versions_from_manifest",
+        middleware_module,
+        "get_versions_from_manifest",
         return_value=version_info,
     )
 

--- a/tests/unit/common/core/test_middleware.py
+++ b/tests/unit/common/core/test_middleware.py
@@ -29,8 +29,8 @@ def test_APIResponseVersionHeaderMiddleware__valid_version_info___adds_version_h
     # Then
     assert result == response
     assert response.headers["Flagsmith-Version"] == "v1.2.3"
-    assert get_response.call_args_list == [mocker.call(request)]
-    assert get_versions_from_manifest.call_args_list == [mocker.call()]
+    get_response.assert_called_once_with(request)
+    get_versions_from_manifest.assert_called_once_with()
 
 
 @pytest.mark.parametrize("version_info", [
@@ -57,5 +57,5 @@ def test_APIResponseVersionHeaderMiddleware__invalid_version_info___adds_unknown
     # Then
     assert result == response
     assert response.headers["Flagsmith-Version"] == "unknown"
-    assert get_response.call_args_list == [mocker.call(request)]
-    assert get_versions_from_manifest.call_args_list == [mocker.call()]
+    get_response.assert_called_once_with(request)
+    get_versions_from_manifest.assert_called_once_with()

--- a/tests/unit/common/core/test_utils.py
+++ b/tests/unit/common/core/test_utils.py
@@ -91,7 +91,7 @@ def test_get_version_info_with_missing_files(fs: FakeFilesystem) -> None:
         "has_email_provider": False,
         "is_enterprise": True,
         "is_saas": False,
-        'package_versions': {'.': 'unknown'},
+        "package_versions": {".": "unknown"},
         "self_hosted_data": {
             "has_logins": False,
             "has_users": False,

--- a/tests/unit/common/core/test_utils.py
+++ b/tests/unit/common/core/test_utils.py
@@ -91,6 +91,7 @@ def test_get_version_info_with_missing_files(fs: FakeFilesystem) -> None:
         "has_email_provider": False,
         "is_enterprise": True,
         "is_saas": False,
+        'package_versions': {'.': 'unknown'},
         "self_hosted_data": {
             "has_logins": False,
             "has_users": False,

--- a/tests/unit/common/core/test_utils.py
+++ b/tests/unit/common/core/test_utils.py
@@ -7,8 +7,8 @@ from pytest_django.fixtures import SettingsWrapper
 
 from common.core.utils import (
     get_file_contents,
+    get_version,
     get_version_info,
-    get_version_number,
     get_versions_from_manifest,
     has_email_provider,
     is_enterprise,
@@ -151,14 +151,14 @@ def test_get_version_info__email_config_disabled__return_expected(
     assert result["has_email_provider"] is False
 
 
-def test_get_version_number__valid_file_contents__returns_version_number(
+def test_get_version__valid_file_contents__returns_version_number(
     fs: FakeFilesystem,
 ) -> None:
     # Given
     fs.create_file("./.versions.json", contents='{".": "v1.2.3"}')
 
     # When
-    result = get_version_number()
+    result = get_version()
 
     # Then
     assert result == "v1.2.3"
@@ -171,7 +171,7 @@ def test_get_version_number__valid_file_contents__returns_version_number(
         "",
     ],
 )
-def test_get_version_number__invalid_file_contents__returns_unknown(
+def test_get_version__invalid_file_contents__returns_unknown(
     fs: FakeFilesystem,
     manifest_contents: str,
 ) -> None:
@@ -179,7 +179,7 @@ def test_get_version_number__invalid_file_contents__returns_unknown(
     fs.create_file("./.versions.json", contents=manifest_contents)
 
     # When
-    result = get_version_number()
+    result = get_version()
 
     # Then
     assert result == "unknown"

--- a/tests/unit/common/core/test_utils.py
+++ b/tests/unit/common/core/test_utils.py
@@ -8,6 +8,7 @@ from pytest_django.fixtures import SettingsWrapper
 from common.core.utils import (
     get_file_contents,
     get_version_info,
+    get_version_number,
     get_versions_from_manifest,
     has_email_provider,
     is_enterprise,
@@ -148,3 +149,37 @@ def test_get_version_info__email_config_disabled__return_expected(
 
     # Then
     assert result["has_email_provider"] is False
+
+
+def test_get_version_number__valid_file_contents__returns_version_number(
+    fs: FakeFilesystem,
+) -> None:
+    # Given
+    fs.create_file("./.versions.json", contents='{".": "v1.2.3"}')
+
+    # When
+    result = get_version_number()
+
+    # Then
+    assert result == "v1.2.3"
+
+
+@pytest.mark.parametrize(
+    "manifest_contents",
+    [
+        '{"foo": "bar"}',
+        "",
+    ],
+)
+def test_get_version_number__invalid_file_contents__returns_unknown(
+    fs: FakeFilesystem,
+    manifest_contents: str,
+) -> None:
+    # Given
+    fs.create_file("./.versions.json", contents=manifest_contents)
+
+    # When
+    result = get_version_number()
+
+    # Then
+    assert result == "unknown"

--- a/tests/unit/common/core/test_utils.py
+++ b/tests/unit/common/core/test_utils.py
@@ -8,6 +8,7 @@ from pytest_django.fixtures import SettingsWrapper
 from common.core.utils import (
     get_file_contents,
     get_version_info,
+    get_versions_from_manifest,
     has_email_provider,
     is_enterprise,
     is_oss,
@@ -21,6 +22,7 @@ pytestmark = pytest.mark.django_db
 def clear_lru_caches() -> Generator[None, None, None]:
     yield
     get_file_contents.cache_clear()
+    get_versions_from_manifest.cache_clear()
     has_email_provider.cache_clear()
     is_enterprise.cache_clear()
     is_saas.cache_clear()


### PR DESCRIPTION
# Changes

Implement a new Django middleware to add the header `X-Flagsmith-Version` to HTTP responses.


# How it was tested

Unit tests in this lib, and integration tests in flagsmith.