### PR TITLE
feat: Generate metrics documentation

### DIFF
--- a/settings/dev.py
+++ b/settings/dev.py
@@ -8,6 +8,14 @@ from task_processor.task_run_method import TaskRunMethod
 
 env = Env()
 
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": ["templates"],
+        "APP_DIRS": True,
+    },
+]
+
 # Settings expected by `mypy_django_plugin`
 AWS_SES_REGION_ENDPOINT: str
 SEGMENT_RULES_CONDITIONS_LIMIT: int
@@ -48,7 +56,8 @@ TASK_DELETE_INCLUDE_FAILED_TASKS = False
 TASK_DELETE_RETENTION_DAYS = 15
 TASK_DELETE_RUN_EVERY = timedelta(days=1)
 TASK_DELETE_RUN_TIME = time(5, 0, 0)
-TASK_PROCESSOR_MODE = False
+TASK_PROCESSOR_MODE = env.bool("RUN_BY_PROCESSOR", default=False)
+DOCGEN_MODE = env.bool("DOCGEN_MODE", default=False)
 TASK_RUN_METHOD = TaskRunMethod.TASK_PROCESSOR
 
 # Avoid models.W042 warnings

--- a/src/common/core/main.py
+++ b/src/common/core/main.py
@@ -52,6 +52,9 @@ def ensure_cli_env() -> typing.Generator[None, None, None]:
         )
         os.environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir_name
 
+    if "docgen" in sys.argv:
+        os.environ["DOCGEN_MODE"] = "true"
+
     if "task-processor" in sys.argv:
         # A hacky way to signal we're not running the API
         os.environ["RUN_BY_PROCESSOR"] = "true"

--- a/src/common/core/management/commands/docgen.py
+++ b/src/common/core/management/commands/docgen.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
 
         metric_parser = subparsers.add_parser(
             "metrics",
-            help="Start the Metrics service.",
+            help="Generate metrics documentation.",
         )
         metric_parser.set_defaults(handle_method=self.handle_metrics)
 

--- a/src/common/core/management/commands/docgen.py
+++ b/src/common/core/management/commands/docgen.py
@@ -52,7 +52,6 @@ class Command(BaseCommand):
                 }
                 for collector in prometheus_client.REGISTRY._collector_to_names
                 if isinstance(collector, MetricWrapperBase)
-                and collector._name.startswith("flagsmith")
             ),
             key=itemgetter("name"),
         )

--- a/src/common/core/management/commands/docgen.py
+++ b/src/common/core/management/commands/docgen.py
@@ -24,8 +24,6 @@ class Command(BaseCommand):
         metric_parser.set_defaults(handle_method=self.handle_metrics)
 
     def initialise(self) -> None:
-        from common.gunicorn import metrics
-
         autodiscover_modules(
             "metrics",
         )

--- a/src/common/core/management/commands/docgen.py
+++ b/src/common/core/management/commands/docgen.py
@@ -24,6 +24,8 @@ class Command(BaseCommand):
         metric_parser.set_defaults(handle_method=self.handle_metrics)
 
     def initialise(self) -> None:
+        from common.gunicorn import metrics  # noqa: F401
+
         autodiscover_modules(
             "metrics",
         )

--- a/src/common/core/management/commands/docgen.py
+++ b/src/common/core/management/commands/docgen.py
@@ -1,0 +1,64 @@
+from operator import itemgetter
+from typing import Any, Callable
+
+import prometheus_client
+from django.core.management import BaseCommand, CommandParser
+from django.template.loader import get_template
+from django.utils.module_loading import autodiscover_modules
+from prometheus_client.metrics import MetricWrapperBase
+
+
+class Command(BaseCommand):
+    help = "Generate documentation for the Flagsmith codebase."
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        subparsers = parser.add_subparsers(
+            title="sub-commands",
+            required=True,
+        )
+
+        metric_parser = subparsers.add_parser(
+            "metrics",
+            help="Start the Metrics service.",
+        )
+        metric_parser.set_defaults(handle_method=self.handle_metrics)
+
+    def initialise(self) -> None:
+        from common.gunicorn import metrics
+
+        autodiscover_modules(
+            "metrics",
+        )
+
+    def handle(
+        self,
+        *args: Any,
+        handle_method: Callable[..., None],
+        **options: Any,
+    ) -> None:
+        self.initialise()
+        handle_method(*args, **options)
+
+    def handle_metrics(self, *args: Any, **options: Any) -> None:
+        template = get_template("docgen-metrics.md")
+
+        flagsmith_metrics = sorted(
+            (
+                {
+                    "name": collector._name,
+                    "documentation": collector._documentation,
+                    "labels": collector._labelnames,
+                    "type": collector._type,
+                }
+                for collector in prometheus_client.REGISTRY._collector_to_names
+                if isinstance(collector, MetricWrapperBase)
+                and collector._name.startswith("flagsmith")
+            ),
+            key=itemgetter("name"),
+        )
+
+        self.stdout.write(
+            template.render(
+                context={"flagsmith_metrics": flagsmith_metrics},
+            )
+        )

--- a/src/common/core/metrics.py
+++ b/src/common/core/metrics.py
@@ -1,4 +1,5 @@
 import prometheus_client
+from django.conf import settings
 
 from common.core.utils import get_version_info
 
@@ -20,4 +21,5 @@ def advertise() -> None:
     ).set(1)
 
 
-advertise()
+if not settings.DOCGEN_MODE:
+    advertise()

--- a/src/common/core/metrics.py
+++ b/src/common/core/metrics.py
@@ -4,7 +4,7 @@ from common.core.utils import get_version_info
 
 flagsmith_build_info = prometheus_client.Gauge(
     "flagsmith_build_info",
-    "Flagsmith version and build information",
+    "Flagsmith version and build information.",
     ["ci_commit_sha", "version"],
     multiprocess_mode="livemax",
 )

--- a/src/common/core/templates/docgen-metrics.md
+++ b/src/common/core/templates/docgen-metrics.md
@@ -4,7 +4,7 @@ title: Metrics
 
 ## Prometheus
 
-To enable the Prometheus `/metrics` endpoint, set the `PROMETHEUS_ENABLED` setting to `true`. 
+To enable the Prometheus `/metrics` endpoint, set the `PROMETHEUS_ENABLED` environment variable to `true`. 
 
 The metrics provided by Flagsmith are described below.
 

--- a/src/common/core/templates/docgen-metrics.md
+++ b/src/common/core/templates/docgen-metrics.md
@@ -1,0 +1,11 @@
+# Prometheus metrics
+
+Flagsmith exports Prometheus metrics described below.
+{% for metric in flagsmith_metrics %}
+## `{{ metric.name }}` {{ metric.type }}
+
+{{ metric.documentation }}
+
+Labels:
+{% for label in metric.labels %} - `{{ label }}`
+{% endfor %}{% endfor %}

--- a/src/common/core/templates/docgen-metrics.md
+++ b/src/common/core/templates/docgen-metrics.md
@@ -4,7 +4,10 @@ title: Metrics
 
 ## Prometheus
 
-Flagsmith exports Prometheus metrics described below.
+To enable the Prometheus `/metrics` endpoint, set the `PROMETHEUS_ENABLED` setting to `true`. 
+
+The metrics provided by Flagsmith are described below.
+
 {% for metric in flagsmith_metrics %}
 ### `{{ metric.name }}`
 

--- a/src/common/core/templates/docgen-metrics.md
+++ b/src/common/core/templates/docgen-metrics.md
@@ -1,8 +1,14 @@
-# Prometheus metrics
+---
+title: Metrics
+---
+
+## Prometheus
 
 Flagsmith exports Prometheus metrics described below.
 {% for metric in flagsmith_metrics %}
-## `{{ metric.name }}` {{ metric.type }}
+### `{{ metric.name }}`
+
+{{ metric.type|title }}.
 
 {{ metric.documentation }}
 

--- a/src/common/gunicorn/metrics.py
+++ b/src/common/gunicorn/metrics.py
@@ -6,17 +6,17 @@ from common.prometheus import Histogram
 
 flagsmith_http_server_requests_total = prometheus_client.Counter(
     "flagsmith_http_server_requests_total",
-    "Total number of HTTP requests",
+    "Total number of HTTP requests.",
     ["route", "method", "response_status"],
 )
 flagsmith_http_server_request_duration_seconds = Histogram(
     "flagsmith_http_server_request_duration_seconds",
-    "HTTP request duration in seconds",
+    "HTTP request duration in seconds.",
     ["route", "method", "response_status"],
 )
 flagsmith_http_server_response_size_bytes = Histogram(
     "flagsmith_http_server_response_size_bytes",
-    "HTTP response size in bytes",
+    "HTTP response size in bytes.",
     ["route", "method", "response_status"],
     buckets=getattr(
         settings,

--- a/src/common/test_tools/__init__.py
+++ b/src/common/test_tools/__init__.py
@@ -1,3 +1,6 @@
-from common.test_tools.types import AssertMetricFixture
+from common.test_tools.types import AssertMetricFixture, SnapshotFixture
 
-__all__ = ("AssertMetricFixture",)
+__all__ = (
+    "AssertMetricFixture",
+    "SnapshotFixture",
+)

--- a/src/common/test_tools/plugin.py
+++ b/src/common/test_tools/plugin.py
@@ -5,7 +5,7 @@ import pytest
 from prometheus_client.metrics import MetricWrapperBase
 from pyfakefs.fake_filesystem import FakeFilesystem
 
-from common.test_tools.types import AssertMetricFixture
+from common.test_tools.types import AssertMetricFixture, SnapshotFixture
 
 
 def assert_metric_impl() -> Generator[AssertMetricFixture, None, None]:
@@ -68,3 +68,14 @@ def flagsmith_markers_marked(
             request.getfixturevalue("saas_mode")
         if marker.name == "enterprise_mode":
             request.getfixturevalue("enterprise_mode")
+
+
+@pytest.fixture
+def snapshot(request: pytest.FixtureRequest) -> SnapshotFixture:
+    def _get_snapshot(name: str = "") -> str:
+        snapshot_name = name or f"{request.node.name}.txt"
+        return open(
+            request.path.parent / f"snapshots/{snapshot_name}",
+        ).read()
+
+    return _get_snapshot

--- a/src/common/test_tools/plugin.py
+++ b/src/common/test_tools/plugin.py
@@ -81,6 +81,18 @@ def flagsmith_markers_marked(
 
 @pytest.fixture
 def snapshot(request: pytest.FixtureRequest) -> SnapshotFixture:
+    """
+    Retrieve a `Snapshot` object getter for the current test.
+    The snapshot is stored in the `snapshots` directory next to the test file.
+
+    Snapshot files are named after the test function name (+ ".txt") by default.
+    If a name is provided to the getter, the snapshot will be stored in a file with that name.
+    The name is relative to the `snapshots` directory.
+
+    When `--snapshot-update` is provided to `pytest`:
+    - The snapshot will be created if it does not exist.
+    - The snapshot will be updated with the string it's being compared to in the test.
+    """
     for_update = request.config.getoption("--snapshot-update")
     snapshot_dir = request.path.parent / "snapshots"
     snapshot_dir.mkdir(exist_ok=True)

--- a/src/common/test_tools/plugin.py
+++ b/src/common/test_tools/plugin.py
@@ -91,7 +91,8 @@ def snapshot(request: pytest.FixtureRequest) -> SnapshotFixture:
 
     When `--snapshot-update` is provided to `pytest`:
     - The snapshot will be created if it does not exist.
-    - The snapshot will be updated with the string it's being compared to in the test.
+    - If the comparison is false, the snapshot will be updated with the string it's being compared to in the test,
+    and the test will be marked as expected to fail.
     """
     for_update = request.config.getoption("--snapshot-update")
     snapshot_dir = request.path.parent / "snapshots"

--- a/src/common/test_tools/plugin.py
+++ b/src/common/test_tools/plugin.py
@@ -82,10 +82,12 @@ def flagsmith_markers_marked(
 @pytest.fixture
 def snapshot(request: pytest.FixtureRequest) -> SnapshotFixture:
     for_update = request.config.getoption("--snapshot-update")
+    snapshot_dir = request.path.parent / "snapshots"
+    snapshot_dir.mkdir(exist_ok=True)
 
     def _get_snapshot(name: str = "") -> Snapshot:
         snapshot_name = name or f"{request.node.name}.txt"
-        snapshot_path = request.path.parent / f"snapshots/{snapshot_name}"
+        snapshot_path = snapshot_dir / snapshot_name
         return Snapshot(snapshot_path, for_update=for_update)
 
     return _get_snapshot

--- a/src/common/test_tools/types.py
+++ b/src/common/test_tools/types.py
@@ -22,7 +22,7 @@ class Snapshot:
     def __init__(self, path: Path, for_update: bool) -> None:
         self.path = path
         mode = "r" if not for_update else "w+"
-        self.content = open(path, encoding="utf-8", mode=mode).read()
+        self.content: str = open(path, encoding="utf-8", mode=mode).read()
         self.for_update = for_update
 
     def __eq__(self, other: object) -> bool:

--- a/src/common/test_tools/types.py
+++ b/src/common/test_tools/types.py
@@ -21,7 +21,8 @@ class SnapshotFixture(Protocol):
 class Snapshot:
     def __init__(self, path: Path, for_update: bool) -> None:
         self.path = path
-        self.content = open(path, encoding="utf-8").read()
+        mode = "r" if not for_update else "w+"
+        self.content = open(path, encoding="utf-8", mode=mode).read()
         self.for_update = for_update
 
     def __eq__(self, other: object) -> bool:

--- a/src/common/test_tools/types.py
+++ b/src/common/test_tools/types.py
@@ -21,14 +21,14 @@ class SnapshotFixture(Protocol):
 class Snapshot:
     def __init__(self, path: Path, for_update: bool) -> None:
         self.path = path
-        self.content = open(path).read()
+        self.content = open(path, encoding="utf-8").read()
         self.for_update = for_update
 
     def __eq__(self, other: object) -> bool:
         if self.content == other:
             return True
         if self.for_update and isinstance(other, str):
-            with open(self.path, "w") as f:
+            with open(self.path, "w", encoding="utf-8") as f:
                 f.write(other)
             pytest.xfail(reason=f"Snapshot updated: {self.path}")
         return False

--- a/src/common/test_tools/types.py
+++ b/src/common/test_tools/types.py
@@ -25,12 +25,13 @@ class Snapshot:
         self.for_update = for_update
 
     def __eq__(self, other: object) -> bool:
-        eq = self.content == other
-        if not eq and isinstance(other, str) and self.for_update:
+        if self.content == other:
+            return True
+        if self.for_update and isinstance(other, str):
             with open(self.path, "w") as f:
                 f.write(other)
-                pytest.xfail(reason=f"Snapshot updated: {self.path}")
-        return eq
+            pytest.xfail(reason=f"Snapshot updated: {self.path}")
+        return False
 
     def __str__(self) -> str:
         return self.content

--- a/src/common/test_tools/types.py
+++ b/src/common/test_tools/types.py
@@ -1,4 +1,7 @@
+from pathlib import Path
 from typing import Protocol
+
+import pytest
 
 
 class AssertMetricFixture(Protocol):
@@ -12,4 +15,24 @@ class AssertMetricFixture(Protocol):
 
 
 class SnapshotFixture(Protocol):
-    def __call__(self, name: str = "") -> str: ...
+    def __call__(self, name: str = "") -> "Snapshot": ...
+
+
+class Snapshot:
+    def __init__(self, path: Path, for_update: bool) -> None:
+        self.path = path
+        self.content = open(path).read()
+        self.for_update = for_update
+
+    def __eq__(self, other: object) -> bool:
+        eq = self.content == other
+        if not eq and isinstance(other, str) and self.for_update:
+            with open(self.path, "w") as f:
+                f.write(other)
+                pytest.xfail(reason=f"Snapshot updated: {self.path}")
+        return eq
+
+    def __str__(self) -> str:
+        return self.content
+
+    __repr__ = __str__

--- a/src/common/test_tools/types.py
+++ b/src/common/test_tools/types.py
@@ -19,6 +19,12 @@ class SnapshotFixture(Protocol):
 
 
 class Snapshot:
+    """
+    Read contents of `path` and make them available for comparison via the `==` operator.
+    If the contents are different, and `Snapshot` initialised in update mode,
+    (e.g. by running `pytest` with `--snapshot-update`), write the new contents to `path`.
+    """
+
     def __init__(self, path: Path, for_update: bool) -> None:
         self.path = path
         mode = "r" if not for_update else "w+"

--- a/src/common/test_tools/types.py
+++ b/src/common/test_tools/types.py
@@ -9,3 +9,7 @@ class AssertMetricFixture(Protocol):
         labels: dict[str, str],
         value: float | int,
     ) -> None: ...
+
+
+class SnapshotFixture(Protocol):
+    def __call__(self, name: str = "") -> str: ...

--- a/src/task_processor/metrics.py
+++ b/src/task_processor/metrics.py
@@ -5,18 +5,18 @@ from common.prometheus import Histogram
 
 flagsmith_task_processor_enqueued_tasks_total = prometheus_client.Counter(
     "flagsmith_task_processor_enqueued_tasks_total",
-    "Total number of enqueued tasks",
+    "Total number of enqueued tasks.",
     ["task_identifier"],
 )
 
 if settings.DOCGEN_MODE or settings.TASK_PROCESSOR_MODE:
     flagsmith_task_processor_finished_tasks_total = prometheus_client.Counter(
         "flagsmith_task_processor_finished_tasks_total",
-        "Total number of finished tasks",
+        "Total number of finished tasks. Only collected by Task Processor. `task_type` label is either `recurring` or `standard`.",
         ["task_identifier", "task_type", "result"],
     )
     flagsmith_task_processor_task_duration_seconds = Histogram(
         "flagsmith_task_processor_task_duration_seconds",
-        "Task processor task duration in seconds",
+        "Task processor task duration in seconds. Only collected by Task Processor. `task_type` label is either `recurring` or `standard`.",
         ["task_identifier", "task_type", "result"],
     )

--- a/src/task_processor/metrics.py
+++ b/src/task_processor/metrics.py
@@ -9,7 +9,7 @@ flagsmith_task_processor_enqueued_tasks_total = prometheus_client.Counter(
     ["task_identifier"],
 )
 
-if settings.TASK_PROCESSOR_MODE:
+if settings.DOCGEN_MODE or settings.TASK_PROCESSOR_MODE:
     flagsmith_task_processor_finished_tasks_total = prometheus_client.Counter(
         "flagsmith_task_processor_finished_tasks_total",
         "Total number of finished tasks",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,6 @@ def prometheus_multiprocess_mode_marked(request: pytest.FixtureRequest) -> None:
 def test_metric() -> prometheus_client.Counter:
     return prometheus_client.Counter(
         "pytest_tests_run_total",
-        "Total number of tests run by pytest",
+        "Total number of tests run by pytest.",
         ["test_name"],
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,24 +1,50 @@
 import os
 from importlib import reload
+from typing import Generator
 
 import prometheus_client
-import prometheus_client.values
 import pytest
 
 pytest_plugins = "flagsmith-test-tools"
 
 
-@pytest.fixture(scope="session")
-def prometheus_multiproc_dir(tmp_path_factory: pytest.TempPathFactory) -> str:
+@pytest.fixture()
+def prometheus_multiproc_dir(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[str, None, None]:
+    """
+    This fixture makes `prometheus_client.multiprocess.MultiProcessCollector` work in pytest.
+    It's not required by general metric-related tests, just the ones that invoke
+    logic that relies directly on `prometheus_client.multiprocess.MultiProcessCollector`.
+    """
+    # Set the environment variable expected by prometheus_client
     os.environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir_path = str(
         tmp_path_factory.mktemp("prometheus_multiproc")
     )
+    # This effectively installs multiprocess mode,
+    # forcing metrics to be written to the file system
+    # and picked up by `MultiProcessCollector`
     reload(prometheus_client.values)
-    return prometheus_multiproc_dir_path
+
+    yield prometheus_multiproc_dir_path
+
+    # Clean up the environment variable after the test
+    # to avoid side effects on other tests
+    del os.environ["PROMETHEUS_MULTIPROC_DIR"]
+    # Reinstall the default mode
+    reload(prometheus_client.values)
+
+
+@pytest.fixture(autouse=True)
+def prometheus_multiprocess_mode_marked(request: pytest.FixtureRequest) -> None:
+    for marker in request.node.iter_markers():
+        if marker.name == "prometheus_multiprocess_mode":
+            request.getfixturevalue("prometheus_multiproc_dir")
+            return
 
 
 @pytest.fixture(scope="session")
-def test_metric(prometheus_multiproc_dir: str) -> prometheus_client.Counter:
+def test_metric() -> prometheus_client.Counter:
     return prometheus_client.Counter(
         "pytest_tests_run_total",
         "Total number of tests run by pytest",

--- a/tests/integration/core/snapshots/test_docgen__metrics__runs_expected.txt
+++ b/tests/integration/core/snapshots/test_docgen__metrics__runs_expected.txt
@@ -4,7 +4,10 @@ title: Metrics
 
 ## Prometheus
 
-Flagsmith exports Prometheus metrics described below.
+To enable the Prometheus `/metrics` endpoint, set the `PROMETHEUS_ENABLED` setting to `true`. 
+
+The metrics provided by Flagsmith are described below.
+
 
 ### `flagsmith_build_info`
 
@@ -62,7 +65,7 @@ Labels:
 
 Counter.
 
-Total number of tests run by pytest
+Total number of tests run by pytest.
 
 Labels:
  - `test_name`

--- a/tests/integration/core/snapshots/test_docgen__metrics__runs_expected.txt
+++ b/tests/integration/core/snapshots/test_docgen__metrics__runs_expected.txt
@@ -4,7 +4,7 @@ title: Metrics
 
 ## Prometheus
 
-To enable the Prometheus `/metrics` endpoint, set the `PROMETHEUS_ENABLED` setting to `true`. 
+To enable the Prometheus `/metrics` endpoint, set the `PROMETHEUS_ENABLED` environment variable to `true`. 
 
 The metrics provided by Flagsmith are described below.
 

--- a/tests/integration/core/snapshots/test_docgen__metrics__runs_expected.txt
+++ b/tests/integration/core/snapshots/test_docgen__metrics__runs_expected.txt
@@ -1,0 +1,69 @@
+---
+title: Metrics
+---
+
+## Prometheus
+
+Flagsmith exports Prometheus metrics described below.
+
+### `flagsmith_build_info`
+
+Gauge.
+
+Flagsmith version and build information.
+
+Labels:
+ - `ci_commit_sha`
+ - `version`
+
+### `flagsmith_http_server_request_duration_seconds`
+
+Histogram.
+
+HTTP request duration in seconds.
+
+Labels:
+ - `route`
+ - `method`
+ - `response_status`
+
+### `flagsmith_http_server_requests`
+
+Counter.
+
+Total number of HTTP requests.
+
+Labels:
+ - `route`
+ - `method`
+ - `response_status`
+
+### `flagsmith_http_server_response_size_bytes`
+
+Histogram.
+
+HTTP response size in bytes.
+
+Labels:
+ - `route`
+ - `method`
+ - `response_status`
+
+### `flagsmith_task_processor_enqueued_tasks`
+
+Counter.
+
+Total number of enqueued tasks.
+
+Labels:
+ - `task_identifier`
+
+### `pytest_tests_run`
+
+Counter.
+
+Total number of tests run by pytest
+
+Labels:
+ - `test_name`
+

--- a/tests/integration/core/snapshots/test_metrics__return_expected.txt
+++ b/tests/integration/core/snapshots/test_metrics__return_expected.txt
@@ -1,3 +1,3 @@
-# HELP pytest_tests_run_total Total number of tests run by pytest
+# HELP pytest_tests_run_total Total number of tests run by pytest.
 # TYPE pytest_tests_run_total counter
 pytest_tests_run_total{test_name="test_metrics__return_expected"} 1.0

--- a/tests/integration/core/snapshots/test_metrics__return_expected.txt
+++ b/tests/integration/core/snapshots/test_metrics__return_expected.txt
@@ -1,0 +1,3 @@
+# HELP pytest_tests_run_total Total number of tests run by pytest
+# TYPE pytest_tests_run_total counter
+pytest_tests_run_total{test_name="test_metrics__return_expected"} 1.0

--- a/tests/integration/core/test_commands.py
+++ b/tests/integration/core/test_commands.py
@@ -1,0 +1,22 @@
+import prometheus_client
+import pytest
+from django.core.management import call_command
+
+from common.test_tools import SnapshotFixture
+
+
+@pytest.mark.django_db
+def test_docgen__metrics__runs_expected(
+    test_metric: prometheus_client.Counter,
+    capsys: pytest.CaptureFixture[str],
+    snapshot: SnapshotFixture,
+) -> None:
+    # Given
+    argv = ["docgen", "metrics"]
+    expected_stdout = snapshot()
+
+    # When
+    call_command(*argv)
+
+    # Then
+    assert capsys.readouterr().out == expected_stdout

--- a/tests/integration/core/test_views.py
+++ b/tests/integration/core/test_views.py
@@ -1,4 +1,5 @@
 import prometheus_client
+import pytest
 from rest_framework.test import APIClient
 
 
@@ -10,6 +11,7 @@ def test_liveness_probe__return_expected(
     assert response.json() == {"status": "ok"}
 
 
+@pytest.mark.prometheus_multiprocess_mode
 def test_metrics__return_expected(
     test_metric: prometheus_client.Counter,
     client: APIClient,

--- a/tests/integration/core/test_views.py
+++ b/tests/integration/core/test_views.py
@@ -2,6 +2,8 @@ import prometheus_client
 import pytest
 from rest_framework.test import APIClient
 
+from common.test_tools import SnapshotFixture
+
 
 def test_liveness_probe__return_expected(
     client: APIClient,
@@ -15,6 +17,7 @@ def test_liveness_probe__return_expected(
 def test_metrics__return_expected(
     test_metric: prometheus_client.Counter,
     client: APIClient,
+    snapshot: SnapshotFixture,
 ) -> None:
     # Arrange
     test_metric.labels(test_name="test_metrics__return_expected").inc()
@@ -24,13 +27,4 @@ def test_metrics__return_expected(
 
     # Assert
     assert response.status_code == 200
-    assert response.content == (
-        "\n".join(
-            [
-                "# HELP pytest_tests_run_total Total number of tests run by pytest",
-                "# TYPE pytest_tests_run_total counter",
-                'pytest_tests_run_total{test_name="test_metrics__return_expected"} 1.0',
-                "",
-            ]
-        ).encode()
-    )
+    assert response.content.decode() == snapshot()

--- a/tests/unit/common/core/test_utils.py
+++ b/tests/unit/common/core/test_utils.py
@@ -1,5 +1,4 @@
 import json
-from typing import Generator
 
 import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
@@ -20,13 +19,12 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture(autouse=True)
-def clear_lru_caches() -> Generator[None, None, None]:
+def clear_lru_caches() -> None:
     get_file_contents.cache_clear()
     get_versions_from_manifest.cache_clear()
     has_email_provider.cache_clear()
     is_enterprise.cache_clear()
     is_saas.cache_clear()
-    yield
 
 
 def test__is_oss_for_enterprise_returns_false(fs: FakeFilesystem) -> None:

--- a/tests/unit/common/core/test_utils.py
+++ b/tests/unit/common/core/test_utils.py
@@ -21,12 +21,12 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture(autouse=True)
 def clear_lru_caches() -> Generator[None, None, None]:
-    yield
     get_file_contents.cache_clear()
     get_versions_from_manifest.cache_clear()
     has_email_provider.cache_clear()
     is_enterprise.cache_clear()
     is_saas.cache_clear()
+    yield
 
 
 def test__is_oss_for_enterprise_returns_false(fs: FakeFilesystem) -> None:

--- a/tests/unit/task_processor/conftest.py
+++ b/tests/unit/task_processor/conftest.py
@@ -20,6 +20,7 @@ def task_processor_mode_marked(request: pytest.FixtureRequest) -> None:
     for marker in request.node.iter_markers():
         if marker.name == "task_processor_mode":
             request.getfixturevalue("task_processor_mode")
+            return
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
This PR adds the `flagsmith docgen metrics` command. The output is valid Markdown describing all Prometheus metrics exported by the application.

Besides that, several improvements and fixes are introduced:
1. Prometheus client multiprocess mode does not support registry cleanup between tests. Because of that, `prometheus_multiproc_dir` is only used with tests where it's needed (currently just the one that tests the `/metrics` endpoint).
2. `snapshot` fixture added to `test_tools` to enable snapshot testing. Snapshots are a convenient way to implement tests where outputs are asserted against reference values. `pytest --snapshot-update` option refreshes the snapshots automatically for the tests being run, and xfails the affected tests.
3. `clear_lru_caches` fixture is tuned to expect dirty caches before the test starts.