### PR TITLE
feat(manual-mode): Add manual model

### DIFF
--- a/settings/dev.py
+++ b/settings/dev.py
@@ -68,5 +68,9 @@ TASK_PROCESSOR_MODE = env.bool("RUN_BY_PROCESSOR", default=False)
 DOCGEN_MODE = env.bool("DOCGEN_MODE", default=False)
 TASK_RUN_METHOD = TaskRunMethod.TASK_PROCESSOR
 
+# To be used by test that depend on task processor to run tasks manually by
+# calling `run_tasks`
+TASK_PROCESSOR_MANUAL_MODE = env.bool("TASK_PROCESSOR_MANUAL_MODE", default=False)
+
 # Avoid models.W042 warnings
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/src/task_processor/decorators.py
+++ b/src/task_processor/decorators.py
@@ -177,7 +177,7 @@ def register_recurring_task(
     first_run_time: time | None = None,
     timeout: timedelta | None = timedelta(minutes=30),
 ) -> typing.Callable[[TaskCallable[TaskParameters]], TaskCallable[TaskParameters]]:
-    if not settings.TASK_PROCESSOR_MODE:
+    if not settings.TASK_PROCESSOR_MODE or settings.TASK_PROCESSOR_MANUAL_MODE:
         # Do not register recurring tasks if not invoked by task processor
         return lambda f: f
 

--- a/src/task_processor/processor.py
+++ b/src/task_processor/processor.py
@@ -151,9 +151,9 @@ def task_metrics(
 def _run_task(
     task: T,
 ) -> typing.Tuple[T, AnyTaskRun]:
-    assert (
-        settings.TASK_PROCESSOR_MODE or settings.TASK_PROCESSOR_MANUAL_MODE
-    ), "Attempt to run tasks in a non-task-processor environment"
+    assert settings.TASK_PROCESSOR_MODE or settings.TASK_PROCESSOR_MANUAL_MODE, (
+        "Attempt to run tasks in a non-task-processor environment"
+    )
     task_identifier = task.task_identifier
     registered_task = get_task(task_identifier)
 
@@ -193,9 +193,9 @@ def _run_task(
         )
 
         if isinstance(e, TaskBackoffError):
-            assert (
-                registered_task.task_type == TaskType.STANDARD
-            ), "Attempt to back off a recurring task (currently not supported)"
+            assert registered_task.task_type == TaskType.STANDARD, (
+                "Attempt to back off a recurring task (currently not supported)"
+            )
             if typing.TYPE_CHECKING:
                 assert isinstance(task, Task)
             if task.num_failures <= 3:


### PR DESCRIPTION
Add `TASK_PROCESSOR_MANUAL_MODE`, which can be used in tests that depend on the task processor by manually calling `run_tasks`.

Usage example: https://github.com/Flagsmith/flagsmith-private/pull/29/files#diff-d390474f304862c0fc4fd05287524aa5702182dccec6db49ff58fab474996630R240