### PR TITLE
feat(test-tools): Add `run_tasks` fixture

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -171,7 +171,7 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
@@ -592,7 +592,7 @@ version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
@@ -801,7 +801,7 @@ version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
     {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
@@ -1082,7 +1082,7 @@ version = "8.3.4"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
     {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
@@ -1141,7 +1141,7 @@ version = "4.10.0"
 description = "A Django plugin for pytest."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest_django-4.10.0-py3-none-any.whl", hash = "sha256:57c74ef3aa9d89cae5a5d73fbb69a720a62673ade7ff13b9491872409a3f5918"},
     {file = "pytest_django-4.10.0.tar.gz", hash = "sha256:1091b20ea1491fd04a310fc9aaff4c01b4e8450e3b157687625e16a6b5f3a366"},
@@ -1685,9 +1685,9 @@ MarkupSafe = ">=2.1.1"
 watchdog = ["watchdog (>=2.3)"]
 
 [extras]
-test-tools = ["pyfakefs"]
+test-tools = ["pyfakefs", "pytest-django"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "38e85051fccc3bf8d25b47f20b680f2d81c388381198df7d2e8a153b9896f9f7"
+content-hash = "2883742dca512df3840b60312ae0d05453b7d61dd245984a1e288de8fbde69eb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,10 @@ dependencies = [
     "requests",
     "simplejson (>=3,<4)",
 ]
-optional-dependencies = { test-tools = ["pyfakefs (>=5,<6)"] }
+optional-dependencies = { test-tools = [
+    "pyfakefs (>=5,<6)",
+    "pytest-django (>=4,<5)",
+] }
 authors = [
     { name = "Matthew Elwell" },
     { name = "Gagan Trivedi" },

--- a/src/common/test_tools/__init__.py
+++ b/src/common/test_tools/__init__.py
@@ -1,6 +1,11 @@
-from common.test_tools.types import AssertMetricFixture, SnapshotFixture
+from common.test_tools.types import (
+    AssertMetricFixture,
+    RunTasksFixture,
+    SnapshotFixture,
+)
 
 __all__ = (
     "AssertMetricFixture",
+    "RunTasksFixture",
     "SnapshotFixture",
 )

--- a/src/common/test_tools/plugin.py
+++ b/src/common/test_tools/plugin.py
@@ -102,7 +102,7 @@ def flagsmith_markers_marked(
 @pytest.fixture(name="run_tasks")
 def run_tasks_impl(
     settings: SettingsWrapper,
-    db: None,
+    transactional_db: None,
     task_processor_mode: None,
 ) -> RunTasksFixture:
     settings.TASK_RUN_METHOD = TaskRunMethod.TASK_PROCESSOR

--- a/src/common/test_tools/plugin.py
+++ b/src/common/test_tools/plugin.py
@@ -7,7 +7,6 @@ from prometheus_client.metrics import MetricWrapperBase
 from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest_django.fixtures import SettingsWrapper
 
-from common.prometheus.utils import reload_metrics
 from common.test_tools.types import (
     AssertMetricFixture,
     RunTasksFixture,
@@ -81,6 +80,8 @@ def task_processor_mode(settings: SettingsWrapper) -> None:
     settings.TASK_PROCESSOR_MODE = True
     # The setting is supposed to be set before the metrics module is imported,
     # so reload it
+    from common.prometheus.utils import reload_metrics
+
     reload_metrics("task_processor.metrics")
 
 

--- a/src/common/test_tools/plugin.py
+++ b/src/common/test_tools/plugin.py
@@ -13,6 +13,7 @@ from common.test_tools.types import (
     Snapshot,
     SnapshotFixture,
 )
+from task_processor.task_run_method import TaskRunMethod
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -104,7 +105,7 @@ def run_tasks_impl(
     db: None,
     task_processor_mode: None,
 ) -> RunTasksFixture:
-    settings.TASK_RUN_METHOD = "TASK_PROCESSOR"
+    settings.TASK_RUN_METHOD = TaskRunMethod.TASK_PROCESSOR
 
     from task_processor.processor import run_tasks
 

--- a/src/common/test_tools/types.py
+++ b/src/common/test_tools/types.py
@@ -1,7 +1,10 @@
 from pathlib import Path
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 import pytest
+
+if TYPE_CHECKING:
+    from task_processor.models import TaskRun
 
 
 class AssertMetricFixture(Protocol):
@@ -12,6 +15,13 @@ class AssertMetricFixture(Protocol):
         labels: dict[str, str],
         value: float | int,
     ) -> None: ...
+
+
+class RunTasksFixture(Protocol):
+    def __call__(
+        self,
+        num_tasks: int,
+    ) -> "list[TaskRun]": ...
 
 
 class SnapshotFixture(Protocol):

--- a/tests/unit/common/test_tools/test_plugin.py
+++ b/tests/unit/common/test_tools/test_plugin.py
@@ -1,9 +1,10 @@
 import prometheus_client
 import pytest
 
-from common.test_tools import AssertMetricFixture
+from common.test_tools import AssertMetricFixture, RunTasksFixture
 from common.test_tools.plugin import assert_metric_impl
 from common.test_tools.utils import edition_printer
+from task_processor.decorators import register_task_handler
 
 
 def test_assert_metrics__asserts_expected(
@@ -55,3 +56,22 @@ def test_saas_mode_marker__is_saas_returns_expected() -> None:
 def test_enterprise_mode_marker__is_enterprise_returns_expected() -> None:
     # When & Then
     assert edition_printer() == "enterprise!"
+
+
+def test_run_tasks__runs_expected_tasks(
+    run_tasks: RunTasksFixture,
+) -> None:
+    # Given
+    @register_task_handler()
+    def my_task() -> None:
+        return None
+
+    my_task.delay()
+
+    # When
+    task_runs = run_tasks(num_tasks=1)
+
+    # Then
+    assert len(task_runs) == 1
+    assert task_runs[0].task.task_identifier == "test_plugin.my_task"
+    assert task_runs[0].result == "SUCCESS"

--- a/tests/unit/common/test_tools/test_plugin.py
+++ b/tests/unit/common/test_tools/test_plugin.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 import prometheus_client
 import pytest
 
@@ -5,6 +7,7 @@ from common.test_tools import AssertMetricFixture, RunTasksFixture
 from common.test_tools.plugin import assert_metric_impl
 from common.test_tools.utils import edition_printer
 from task_processor.decorators import register_task_handler
+from task_processor.models import Task
 
 
 def test_assert_metrics__asserts_expected(
@@ -75,3 +78,26 @@ def test_run_tasks__runs_expected_tasks(
     assert len(task_runs) == 1
     assert task_runs[0].task.task_identifier == "test_plugin.my_task"
     assert task_runs[0].result == "SUCCESS"
+
+
+def test_run_tasks__delay_inside_task__runs_expected(
+    run_tasks: RunTasksFixture,
+) -> None:
+    # Given
+    @register_task_handler()
+    def my_task() -> None:
+        return None
+
+    @register_task_handler()
+    def calling_task() -> None:
+        my_task.delay(delay_until=datetime.now() + timedelta(hours=1))
+
+    calling_task.delay()
+
+    # When
+    task_runs = run_tasks(num_tasks=1)
+
+    # Then
+    assert len(task_runs) == 1
+    assert Task.objects.count() == 2
+    assert Task.objects.latest("scheduled_for").task_identifier == "test_plugin.my_task"

--- a/tests/unit/common/test_tools/test_plugin.py
+++ b/tests/unit/common/test_tools/test_plugin.py
@@ -85,8 +85,7 @@ def test_run_tasks__delay_inside_task__runs_expected(
 ) -> None:
     # Given
     @register_task_handler()
-    def my_task() -> None:
-        return None
+    def my_task() -> None: ...
 
     @register_task_handler()
     def calling_task() -> None:

--- a/tests/unit/task_processor/conftest.py
+++ b/tests/unit/task_processor/conftest.py
@@ -3,7 +3,6 @@ import typing
 import pytest
 from pytest_django.fixtures import SettingsWrapper
 
-from common.prometheus.utils import reload_metrics
 from task_processor.task_registry import RegisteredTask
 
 
@@ -33,22 +32,6 @@ def current_database(
     if database == "task_processor":
         settings.DATABASE_ROUTERS = ["task_processor.routers.TaskProcessorRouter"]
     return database
-
-
-@pytest.fixture()
-def task_processor_mode(settings: SettingsWrapper) -> None:
-    settings.TASK_PROCESSOR_MODE = True
-    # The setting is supposed to be set before the metrics module is imported,
-    # so reload it
-    reload_metrics("task_processor.metrics")
-
-
-@pytest.fixture(autouse=True)
-def task_processor_mode_marked(request: pytest.FixtureRequest) -> None:
-    for marker in request.node.iter_markers():
-        if marker.name == "task_processor_mode":
-            request.getfixturevalue("task_processor_mode")
-            return
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
This PR is a PoC for the `run_tasks` fixture.

By default, we run tasks [synchronously](https://github.com/Flagsmith/flagsmith/blob/12232660509824d11d18688b8286cb91009ee0a5/api/conftest.py#L837-L838) in tests. However, in order to test complex workflows that require asynchronous processing, we need a way to schedule and run tasks as they would've been run with `TASK_PROCESSOR_MODE` enabled. The new fixture makes sure `TASK_RUN_METHOD` is set to `TASK_PROCESSOR` in the context of a test using it, and allows to run a pre-determined number of tasks to verify their operation.

Usage:

```python
def test_logic_involving_async_processing(run_tasks: RunTasksFixture) -> None:
   # When
   # code scheduling a task is called
   my_logic()

   # Then
   task_runs = run_tasks(num_tasks=1)

   # The task was failed
   assert task_runs[0].result == "FAILURE"
```

We can probably pack the assertion logic in a fixture as well to allow something like an `AssertTaskRunFixture`:

```python
def test_logic_involving_async_processing(assert_task_run: AssertTaskRunFixture) -> None:
   # When
   my_logic()

   # Then
   assert_task_run("my_module.my_task", "FAILURE")
```