### PR TITLE
feat(utils): Allow for explicit use of database replicas

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -24,14 +24,14 @@ jobs:
         image: postgres:15.5-alpine
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
-        ports: ['5432:5432']
+        ports: ["6543:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
       task-processor-database:
         image: postgres:15.5-alpine
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
-        ports: ['5433:5432']
+        ports: ["6544:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - default-database:/var/lib/postgresql/data
     ports:
-      - 5432:5432
+      - 6543:5432
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       TZ: UTC
@@ -31,7 +31,7 @@ services:
     volumes:
       - task-processor-database:/var/lib/postgresql/data
     ports:
-      - 5433:5432
+      - 6544:5432
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       TZ: UTC

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -33,7 +33,12 @@ DATABASES = {
     "task_processor": dj_database_url.parse(
         "postgresql://postgres@localhost:6544/postgres",
     ),
+    # Dummy replicas
+    "replica_1": default_database_url,
+    "replica_2": default_database_url,
+    "replica_3": default_database_url,
 }
+REPLICA_READ_STRATEGY = "distributed"
 TASK_PROCESSOR_DATABASES = ["default"]
 INSTALLED_APPS = [
     "django.contrib.auth",

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -37,6 +37,8 @@ DATABASES = {
     "replica_1": default_database_url,
     "replica_2": default_database_url,
     "replica_3": default_database_url,
+    "cross_region_replica_1": default_database_url,
+    "cross_region_replica_2": default_database_url,
 }
 REPLICA_READ_STRATEGY = "distributed"
 TASK_PROCESSOR_DATABASES = ["default"]

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -25,17 +25,13 @@ PROMETHEUS_ENABLED = True
 # Settings required for tests
 SECRET_KEY = "test"
 DATABASES = {
-    "default": dj_database_url.parse(
-        env(
-            "DATABASE_URL",
-            default="postgresql://postgres@localhost:5432/postgres",
-        ),
+    "default": (
+        default_database_url := dj_database_url.parse(
+            "postgresql://postgres@localhost:6543/postgres",
+        )
     ),
     "task_processor": dj_database_url.parse(
-        env(
-            "TASK_PROCESSOR_DATABASE_URL",
-            default="postgresql://postgres@localhost:5433/postgres",
-        ),
+        "postgresql://postgres@localhost:6544/postgres",
     ),
 }
 TASK_PROCESSOR_DATABASES = ["default"]

--- a/src/common/core/__init__.py
+++ b/src/common/core/__init__.py
@@ -1,0 +1,6 @@
+import enum
+
+
+class ReplicaReadStrategy(enum.StrEnum):
+    DISTRIBUTED = enum.auto()
+    SEQUENTIAL = enum.auto()

--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -1,4 +1,3 @@
-import enum
 import json
 import logging
 import pathlib
@@ -14,6 +13,8 @@ from django.db import connections
 from django.db.models import Manager, Model
 from django.db.utils import OperationalError
 
+from common.core import ReplicaReadStrategy
+
 logger = logging.getLogger(__name__)
 
 UNKNOWN = "unknown"
@@ -23,11 +24,6 @@ ModelType = TypeVar("ModelType", bound=Model)
 
 ReplicaNamePrefix = Literal["replica_", "cross_region_replica_"]
 _replica_sequential_names_by_prefix: dict[ReplicaNamePrefix, Iterator[str]] = {}
-
-
-class ReplicaReadStrategy(enum.StrEnum):
-    DISTRIBUTED = enum.auto()
-    SEQUENTIAL = enum.auto()
 
 
 class SelfHostedData(TypedDict):

--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 UNKNOWN = "unknown"
 VERSIONS_INFO_FILE_LOCATION = ".versions.json"
 
-ModelType = TypeVar("ModelType", bound=Model)
+ManagerType = TypeVar("ManagerType", bound=Manager[Model])
 
 ReplicaNamePrefix = Literal["replica_", "cross_region_replica_"]
 _replica_sequential_names_by_prefix: dict[ReplicaNamePrefix, Iterator[str]] = {}
@@ -131,9 +131,9 @@ def get_file_contents(file_path: str) -> str | None:
 
 
 def using_database_replica(
-    manager: Manager[ModelType],
+    manager: ManagerType,
     replica_prefix: ReplicaNamePrefix = "replica_",
-) -> Manager[ModelType]:
+) -> ManagerType:
     """Attempts to bind a manager to a healthy database replica"""
     local_replicas = [name for name in connections if name.startswith(replica_prefix)]
 

--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -157,7 +157,7 @@ def using_database_replica(
                 chosen_replica = attempted_replica
                 break
             except OperationalError:
-                logger.warning(f"Replica '{attempted_replica}' is not available.")
+                logger.exception(f"Replica '{attempted_replica}' is not available.")
                 continue
 
     if settings.REPLICA_READ_STRATEGY == ReplicaReadStrategy.DISTRIBUTED:
@@ -168,7 +168,7 @@ def using_database_replica(
                 chosen_replica = attempted_replica
                 break
             except OperationalError:
-                logger.warning(f"Replica '{attempted_replica}' is not available.")
+                logger.exception(f"Replica '{attempted_replica}' is not available.")
                 local_replicas.remove(attempted_replica)
                 continue
 

--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -5,7 +5,7 @@ import pathlib
 import random
 from functools import lru_cache
 from itertools import cycle
-from typing import Iterator, NotRequired, TypedDict, TypeVar
+from typing import Iterator, Literal, NotRequired, TypedDict, TypeVar
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -21,7 +21,8 @@ VERSIONS_INFO_FILE_LOCATION = ".versions.json"
 
 ModelType = TypeVar("ModelType", bound=Model)
 
-_replica_sequential_names_by_prefix: dict[str, Iterator[str]] = {}
+ReplicaNamePrefix = Literal["replica_", "cross_region_replica_"]
+_replica_sequential_names_by_prefix: dict[ReplicaNamePrefix, Iterator[str]] = {}
 
 
 class ReplicaReadStrategy(enum.StrEnum):
@@ -135,7 +136,7 @@ def get_file_contents(file_path: str) -> str | None:
 
 def using_database_replica(
     manager: Manager[ModelType],
-    replica_prefix: str = "replica_",
+    replica_prefix: ReplicaNamePrefix = "replica_",
 ) -> Manager[ModelType]:
     """Attempts to bind a manager to a healthy database replica"""
     local_replicas = [name for name in connections if name.startswith(replica_prefix)]

--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -174,6 +174,8 @@ def using_database_replica(
         if replica_prefix == "replica_":
             logger.warning("Falling back to cross-region replicas, if any.")
             return using_database_replica(manager, "cross_region_replica_")
-        raise OperationalError("No available replicas")
+
+        logger.warning("No replicas available.")
+        return manager
 
     return manager.db_manager(chosen_replica)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+from typing import Callable
+
+GetLogsFixture = Callable[[str], list[tuple[str, str]]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,19 @@ from typing import Generator
 import prometheus_client
 import pytest
 
+from tests import GetLogsFixture
+
 pytest_plugins = "flagsmith-test-tools"
+
+
+@pytest.fixture()
+def get_logs(caplog: pytest.LogCaptureFixture) -> GetLogsFixture:
+    caplog.set_level("DEBUG")
+
+    def _logs(module: str) -> list[tuple[str, str]]:
+        return [(r.levelname, r.message) for r in caplog.records if r.name == module]
+
+    return _logs
 
 
 @pytest.fixture()

--- a/tests/unit/common/core/test_utils.py
+++ b/tests/unit/common/core/test_utils.py
@@ -9,7 +9,7 @@ from pytest_django.fixtures import DjangoAssertNumQueries, SettingsWrapper
 from pytest_mock import MockerFixture, MockType
 
 from common.core.utils import (
-    _sequential_replica_manager,
+    _replica_sequential_names_by_prefix,
     get_file_contents,
     get_version,
     get_version_info,
@@ -36,7 +36,7 @@ def clear_lru_caches() -> None:
 @pytest.fixture(autouse=True)
 def clear_sequential_replica_manager() -> None:
     """Reset the sequential replica cycle"""
-    _sequential_replica_manager.clear()
+    _replica_sequential_names_by_prefix.clear()
 
 
 @pytest.fixture()

--- a/tests/unit/common/core/test_utils.py
+++ b/tests/unit/common/core/test_utils.py
@@ -43,7 +43,7 @@ def clear_sequential_replica_manager() -> None:
 @pytest.fixture()
 def bad_replica(mocker: MockerFixture) -> MockType:
     """An unhealthy replica"""
-    replica: MockType = mocker.Mock()
+    replica: MockType = mocker.Mock(spec=connections["default"])
     replica.ensure_connection.side_effect = OperationalError("Connection failed")
     return replica
 


### PR DESCRIPTION
Contributes to https://github.com/Flagsmith/flagsmith/issues/5814.

This is meant to replace the `PrimaryReplicaRouter` [functionality](https://github.com/Flagsmith/flagsmith/blob/5de0b425b0ee16b16bfb0fb33b067fa314d040fb/api/app/routers.py#L49) in the core API.

## Changes

Introduces a utility `using_database_replica` that wraps any Django model manager binding it to a database replica according to `settings.REPLICA_READ_STRATEGY`.

## Tests

Unit tests.