### PR TITLE
feat(utils): New is_database_replica_setup utility

### DIFF
--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -130,6 +130,7 @@ def get_file_contents(file_path: str) -> str | None:
         return None
 
 
+@lru_cache()
 def is_database_replica_setup() -> bool:
     """Checks if any database replica is set up"""
     return any(

--- a/tests/unit/common/core/test_utils.py
+++ b/tests/unit/common/core/test_utils.py
@@ -223,6 +223,7 @@ def test_is_database_replica_setup__tells_whether_any_replica_is_present(
     mocker: MockerFixture,
 ) -> None:
     # Given
+    is_database_replica_setup.cache_clear()
     mocker.patch(
         "common.core.utils.connections",
         {name: connections["default"] for name in database_names},


### PR DESCRIPTION
Contributes to https://github.com/Flagsmith/flagsmith/issues/5814

Add a new `is_database_replica_setup` utility to help avoiding `using_database_replica` when no replicas are given.