### PR TITLE
fix: Remove `PROMETHEUS_MULTIPROC_DIR` cleanup logic

### DIFF
--- a/src/common/core/main.py
+++ b/src/common/core/main.py
@@ -3,15 +3,13 @@ import logging
 import os
 import sys
 import typing
-from tempfile import gettempdir
+from tempfile import mkdtemp
 
 from django.core.management import (
     execute_from_command_line as django_execute_from_command_line,
 )
 
 from common.core.cli import healthcheck
-from common.core.constants import DEFAULT_PROMETHEUS_MULTIPROC_DIR_NAME
-from common.core.utils import clear_directory, make_writable_directory
 
 logger = logging.getLogger(__name__)
 
@@ -37,13 +35,8 @@ def ensure_cli_env() -> typing.Generator[None, None, None]:
     # TODO @khvn26 Move logging setup to here
 
     # Prometheus multiproc support
-    prom_dir = os.environ.setdefault(
-        "PROMETHEUS_MULTIPROC_DIR",
-        os.path.join(gettempdir(), DEFAULT_PROMETHEUS_MULTIPROC_DIR_NAME),
-    )
-    if os.path.exists(prom_dir):
-        clear_directory(prom_dir)
-    make_writable_directory(prom_dir)
+    if not os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        os.environ["PROMETHEUS_MULTIPROC_DIR"] = mkdtemp(prefix="flagsmith-prometheus-")
 
     # Currently we don't install Flagsmith modules as a package, so we need to add
     # $CWD to the Python path to be able to import them

--- a/src/common/core/utils.py
+++ b/src/common/core/utils.py
@@ -1,9 +1,7 @@
 import json
 import logging
-import os
 import pathlib
 import random
-import shutil
 from functools import lru_cache
 from itertools import cycle
 from typing import (
@@ -200,20 +198,3 @@ def using_database_replica(
         return manager
 
     return manager.db_manager(chosen_replica)
-
-
-def clear_directory(directory_path: str) -> None:
-    """
-    Safely clear a directory including all subdirectories and files.
-    """
-    for p in pathlib.Path(directory_path).rglob("*"):
-        try:
-            p.chmod(0o700)
-        except (PermissionError, FileNotFoundError):  # pragma: no cover
-            pass
-
-    shutil.rmtree(directory_path, ignore_errors=True)
-
-
-def make_writable_directory(directory_path: str) -> None:
-    os.makedirs(directory_path, exist_ok=True, mode=0o700)

--- a/tests/integration/core/test_main.py
+++ b/tests/integration/core/test_main.py
@@ -3,7 +3,6 @@ import subprocess
 import django
 import pytest
 from django.core.management import ManagementUtility
-from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest_httpserver import HTTPServer
 
 from common.core.main import main
@@ -107,25 +106,6 @@ def test_main__healthcheck_http__server_invalid_response__runs_expected(
     # When & Then
     with pytest.raises(Exception):
         main(argv)
-
-
-def test_main__prometheus_multiproc_remove_dir_on_start_default__expected(
-    monkeypatch: pytest.MonkeyPatch,
-    fs: FakeFilesystem,
-) -> None:
-    # Given
-    monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR_KEEP", raising=False)
-
-    fs.create_file(
-        "/tmp/flagsmith-prometheus/some_metric_file.db",
-        create_missing_dirs=True,
-    )
-
-    # When
-    main(["flagsmith"])
-
-    # Then
-    assert not fs.exists("/tmp/flagsmith-prometheus/some_metric_file.db")
 
 
 def test_main__no_django_configured__expected_0(


### PR DESCRIPTION
Fixes #122.

In this PR, we stop assuming the runtime environment, and defer temporary directory management to outside processes. 

This fixes an issue when files inside `PROMETHEUS_MULTIPROC_DIR` got unexpectedly deleted during runtime.

PR 1/2; PR 2/2 expected to the Core repo.