### PR TITLE
fix: Noise in tracebacks

### DIFF
--- a/src/common/core/main.py
+++ b/src/common/core/main.py
@@ -67,7 +67,7 @@ def execute_from_command_line(argv: list[str]) -> None:
             "checktaskprocessorthreadhealth": healthcheck.main,
         }[subcommand]
     except (IndexError, KeyError):
-        pass
+        logger.info("Invoking Django")
     else:
         return subcommand_main(
             argv[2:],


### PR DESCRIPTION
In this PR, we stop invoking Django management commands from under the `except` block so the tracebacks we see for actual errors are more accurate.