### PR TITLE
fix(OTel): Сatalogue event names don't match OTel's normalised form

### DIFF
--- a/src/common/core/docgen/events.py
+++ b/src/common/core/docgen/events.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Iterator
 
+from common.core.otel import get_otel_event_name
+
 
 class DocgenEventsWarning(UserWarning):
     """Raised by the events scanner when a call site can't be resolved."""
@@ -317,9 +319,11 @@ def _build_entry_from_emit_call(
         )
         return None
     attributes = scope.bound_attrs | _kwargs_as_attributes(node.keywords)
-    name = f"{scope.domain}.{event_arg.value}" if scope.domain else event_arg.value
     return EventEntry(
-        name=name,
+        name=get_otel_event_name(
+            logger_name=scope.domain or None,
+            body=event_arg.value,
+        ),
         level=func.attr,
         attributes=attributes,
         locations=[SourceLocation(path=path, line=node.lineno)],

--- a/src/common/core/otel.py
+++ b/src/common/core/otel.py
@@ -54,6 +54,19 @@ _RESERVED_KEYS = frozenset(
 )
 
 
+def get_otel_event_name(*, logger_name: str | None, body: str) -> str:
+    """Build the event name that reaches OTel from a structlog `(logger, event)`.
+
+    The body is normalised via `inflection.underscore` so hyphens and CamelCase
+    collapse to snake_case. Empty bodies fall back to ``"unknown"``. The logger
+    name, when present, is prefixed verbatim.
+    """
+    normalised = inflection.underscore(body) if body else "unknown"
+    if logger_name:
+        return f"{logger_name}.{normalised}"
+    return normalised
+
+
 def add_otel_trace_context(
     logger: structlog.types.WrappedLogger,
     method_name: str,
@@ -95,10 +108,10 @@ def make_structlog_otel_processor(logger_provider: LoggerProvider) -> Processor:
             attributes[key] = str(value)
 
         body = event_dict.get("event", "")
-        logger_name = event_dict.get("logger")
-        event_name = inflection.underscore(body) if body else "unknown"
-        if logger_name:
-            event_name = f"{logger_name}.{event_name}"
+        event_name = get_otel_event_name(
+            logger_name=event_dict.get("logger"),
+            body=body,
+        )
 
         # Some observability platforms don't surface OTel's EventName.
         # Keep a custom attribute for better visibility.

--- a/tests/unit/common/core/test_docgen_events.py
+++ b/tests/unit/common/core/test_docgen_events.py
@@ -108,6 +108,42 @@ logger.exception("import.failed")
             """\
 import structlog
 
+logger = structlog.get_logger("app_analytics")
+logger.warning("no-analytics-database-configured")
+""",
+            [
+                EventEntry(
+                    name="app_analytics.no_analytics_database_configured",
+                    level="warning",
+                    attributes=frozenset(),
+                    locations=[SourceLocation(path=PATH, line=4)],
+                ),
+            ],
+            [],
+            id="hyphenated-event-body-normalised-to-snake_case",
+        ),
+        pytest.param(
+            """\
+import structlog
+
+logger = structlog.get_logger("segments")
+logger.info("NewSegmentRevision")
+""",
+            [
+                EventEntry(
+                    name="segments.new_segment_revision",
+                    level="info",
+                    attributes=frozenset(),
+                    locations=[SourceLocation(path=PATH, line=4)],
+                ),
+            ],
+            [],
+            id="camel-case-event-body-normalised-to-snake_case",
+        ),
+        pytest.param(
+            """\
+import structlog
+
 logger = structlog.get_logger("sentry_change_tracking")
 
 


### PR DESCRIPTION
Contributes to #201.

The docgen events catalogue was rendering event bodies verbatim, but `common.core.otel`'s structlog processor runs them through `inflection.underscore` before handing them to OTel. So `logger.warning("no-analytics-database-configured")` ended up as `no_analytics_database_configured` downstream, and stakeholders searching the catalogue for the name they saw in OTel couldn't find it.

Extracts the `(logger_name, body) → event_name` composition out of the structlog processor into a new `get_otel_event_name` helper and calls it from both places. The catalogue now shows the same names stakeholders see in OTel, and any future tweak to the name contract stays in sync by construction.