### PR TITLE
refactor: Strip site-specific framing from docgen templates

### DIFF
--- a/src/common/core/templates/docgen-events.md
+++ b/src/common/core/templates/docgen-events.md
@@ -1,14 +1,3 @@
----
-title: Events
-sidebar_label: Events
-sidebar_position: 30
----
-
-Flagsmith backend emits [OpenTelemetry events](https://opentelemetry.io/docs/specs/otel/logs/data-model/#events)
-that can be ingested to downstream observability systems and/or a data warehouse of your choice via OTLP.
-To learn how to configure this, see [OpenTelemetry](deployment-self-hosting/scaling-and-performance/opentelemetry).
-
-## Event catalogue
 {% for event in flagsmith_events %}
 ### `{{ event.name }}`
 

--- a/src/common/core/templates/docgen-metrics.md
+++ b/src/common/core/templates/docgen-metrics.md
@@ -1,17 +1,3 @@
----
-title: Metrics
-sidebar_label: Metrics
-sidebar_position: 20
----
-
-## Prometheus
-
-To enable the Prometheus `/metrics` endpoint, set the `PROMETHEUS_ENABLED` environment variable to `true`.
-
-When enabled, Flagsmith serves the `/metrics` endpoint on port 9100.
-
-The metrics provided by Flagsmith are described below.
-
 {% for metric in flagsmith_metrics %}
 ### `{{ metric.name }}`
 

--- a/tests/integration/core/snapshots/test_docgen__events__runs_expected.txt
+++ b/tests/integration/core/snapshots/test_docgen__events__runs_expected.txt
@@ -1,14 +1,3 @@
----
-title: Events
-sidebar_label: Events
-sidebar_position: 30
----
-
-Flagsmith backend emits [OpenTelemetry events](https://opentelemetry.io/docs/specs/otel/logs/data-model/#events)
-that can be ingested to downstream observability systems and/or a data warehouse of your choice via OTLP.
-To learn how to configure this, see [OpenTelemetry](deployment-self-hosting/scaling-and-performance/opentelemetry).
-
-## Event catalogue
 
 ### `code_references.scan.created`
 

--- a/tests/integration/core/snapshots/test_docgen__metrics__runs_expected.txt
+++ b/tests/integration/core/snapshots/test_docgen__metrics__runs_expected.txt
@@ -1,17 +1,3 @@
----
-title: Metrics
-sidebar_label: Metrics
-sidebar_position: 20
----
-
-## Prometheus
-
-To enable the Prometheus `/metrics` endpoint, set the `PROMETHEUS_ENABLED` environment variable to `true`.
-
-When enabled, Flagsmith serves the `/metrics` endpoint on port 9100.
-
-The metrics provided by Flagsmith are described below.
-
 
 ### `flagsmith_build_info`
 


### PR DESCRIPTION
Contributes to #201

Strip both `docgen-events.md` and `docgen-metrics.md` down to pure catalogue data. Consumers of `flagsmith docgen {events,metrics}` previously got a full page with hard-coded framing — frontmatter, intro prose, and a section heading. The OpenTelemetry link in the events header turned out to be a relative URL that only resolved correctly when the events page happened to live where the library author had put it; any move in the consumer's docs tree silently broke it.

The templates now emit only the per-event / per-metric `### ...` entries. Consumers supply their own frontmatter and intro — either by writing an MDX page that imports the generated fragment as a partial, or by concatenating a hand-maintained header before the docgen output in their build.

### BREAKING CHANGE

Consumers of `docgen events` / `docgen metrics` must now supply their own page header. The generated file alone is no longer a publishable docs page.

For the MDX partial pattern, rename the output to an underscore-prefixed file (Docusaurus treats `_foo.md` as a non-routed partial) and import it from a hand-authored `.mdx`:

```mdx
---
title: Events
sidebar_label: Events
sidebar_position: 30
---

import EventCatalogue from './_events-catalogue.md';

Your intro prose here, linking to your OTel docs at the right path for your site.

## Event catalogue

<EventCatalogue />
```

Then in your Makefile:

```makefile
poetry run flagsmith docgen events > path/to/_events-catalogue.md
```

## How did you test this code?

Regenerated the two snapshot fixtures (`test_docgen__events__runs_expected.txt`, `test_docgen__metrics__runs_expected.txt`) via `pytest --snapshot-update`, then ran the tests normally to confirm they pass.