### PR TITLE
refactor: simplify run_recurring_tasks for single-task processing

### DIFF
--- a/src/task_processor/managers.py
+++ b/src/task_processor/managers.py
@@ -14,5 +14,8 @@ class TaskManager(Manager["Task"]):
 
 
 class RecurringTaskManager(Manager["RecurringTask"]):
-    def get_tasks_to_process(self) -> "RawQuerySet[RecurringTask]":
-        return self.raw("SELECT * FROM get_recurringtasks_to_process()")
+    def get_task_to_process(self) -> "RecurringTask | None":
+        return next(
+            iter(self.raw("SELECT * FROM get_recurringtasks_to_process()")),
+            None,
+        )

--- a/src/task_processor/processor.py
+++ b/src/task_processor/processor.py
@@ -77,7 +77,7 @@ def run_recurring_tasks(database: str) -> list[RecurringTaskRun]:
     if task is None:
         return []
 
-    logger.debug("Running recurring task")
+    logger.debug(f"Running recurring task '{task.task_identifier}'")
 
     if not task.is_task_registered:
         # This is necessary to ensure that old instances of the task processor,
@@ -88,10 +88,11 @@ def run_recurring_tasks(database: str) -> list[RecurringTaskRun]:
             task.delete(using=database)
         return []
 
-    task_run = None
+    task_run: RecurringTaskRun | None = None
     if task.should_execute:
-        task, task_run = _run_task(task)
-        assert isinstance(task_run, RecurringTaskRun)
+        task, run = _run_task(task)
+        assert isinstance(run, RecurringTaskRun)
+        task_run = run
     else:
         task.unlock()
 
@@ -99,7 +100,7 @@ def run_recurring_tasks(database: str) -> list[RecurringTaskRun]:
 
     if task_run:
         task_run.save(using=database)
-        logger.debug("Finished running recurring task")
+        logger.debug(f"Finished running recurring task '{task.task_identifier}'")
         return [task_run]
 
     return []

--- a/src/task_processor/processor.py
+++ b/src/task_processor/processor.py
@@ -68,7 +68,7 @@ def run_tasks(database: str, num_tasks: int = 1) -> list[TaskRun]:
     return []
 
 
-def run_recurring_tasks(database: str) -> RecurringTaskRun | None:
+def run_recurring_task(database: str) -> RecurringTaskRun | None:
     # NOTE: We will probably see a lot of delay in the execution of recurring tasks
     # if the tasks take longer then `run_every` to execute. This is not
     # a problem for now, but we should be mindful of this limitation

--- a/src/task_processor/processor.py
+++ b/src/task_processor/processor.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from importlib.metadata import version
 
 from django.conf import settings
+from django.db import close_old_connections
 from django.utils import timezone
 from opentelemetry import context as otel_context
 from opentelemetry import propagate, trace
@@ -93,6 +94,10 @@ def run_recurring_task(database: str) -> RecurringTaskRun | None:
         task, run = _run_task(task)
         assert isinstance(run, RecurringTaskRun)
         task_run = run
+        # task.run() may have idled the DB connection past the server's
+        # session timeout; drop stale connections so the saves below open
+        # a fresh one. See Sentry FLAGSMITH-API-5EM.
+        close_old_connections()
     else:
         task.unlock()
 

--- a/src/task_processor/processor.py
+++ b/src/task_processor/processor.py
@@ -68,14 +68,14 @@ def run_tasks(database: str, num_tasks: int = 1) -> list[TaskRun]:
     return []
 
 
-def run_recurring_tasks(database: str) -> list[RecurringTaskRun]:
+def run_recurring_tasks(database: str) -> RecurringTaskRun | None:
     # NOTE: We will probably see a lot of delay in the execution of recurring tasks
     # if the tasks take longer then `run_every` to execute. This is not
     # a problem for now, but we should be mindful of this limitation
     task_manager: RecurringTaskManager = RecurringTask.objects.db_manager(database)
     task = task_manager.get_task_to_process()
     if task is None:
-        return []
+        return None
 
     logger.debug(f"Running recurring task '{task.task_identifier}'")
 
@@ -86,7 +86,7 @@ def run_recurring_tasks(database: str) -> list[RecurringTaskRun]:
         task_age = timezone.now() - task.created_at
         if task_age > UNREGISTERED_RECURRING_TASK_GRACE_PERIOD:
             task.delete(using=database)
-        return []
+        return None
 
     task_run: RecurringTaskRun | None = None
     if task.should_execute:
@@ -101,9 +101,9 @@ def run_recurring_tasks(database: str) -> list[RecurringTaskRun]:
     if task_run:
         task_run.save(using=database)
         logger.debug(f"Finished running recurring task '{task.task_identifier}'")
-        return [task_run]
+        return task_run
 
-    return []
+    return None
 
 
 def _run_task(

--- a/src/task_processor/processor.py
+++ b/src/task_processor/processor.py
@@ -73,41 +73,34 @@ def run_recurring_tasks(database: str) -> list[RecurringTaskRun]:
     # if the tasks take longer then `run_every` to execute. This is not
     # a problem for now, but we should be mindful of this limitation
     task_manager: RecurringTaskManager = RecurringTask.objects.db_manager(database)
-    tasks = task_manager.get_tasks_to_process()
-    if tasks:
-        logger.debug(f"Running {len(tasks)} recurring task(s)")
+    task = task_manager.get_task_to_process()
+    if task is None:
+        return []
 
-        task_runs = []
+    logger.debug("Running recurring task")
 
-        for task in tasks:
-            if not task.is_task_registered:
-                # This is necessary to ensure that old instances of the task processor,
-                # which may still be running during deployment, do not remove tasks added by new instances.
-                # Reference: https://github.com/Flagsmith/flagsmith/issues/2551
-                task_age = timezone.now() - task.created_at
-                if task_age > UNREGISTERED_RECURRING_TASK_GRACE_PERIOD:
-                    task.delete(using=database)
-                continue
+    if not task.is_task_registered:
+        # This is necessary to ensure that old instances of the task processor,
+        # which may still be running during deployment, do not remove tasks added by new instances.
+        # Reference: https://github.com/Flagsmith/flagsmith/issues/2551
+        task_age = timezone.now() - task.created_at
+        if task_age > UNREGISTERED_RECURRING_TASK_GRACE_PERIOD:
+            task.delete(using=database)
+        return []
 
-            if task.should_execute:
-                task, task_run = _run_task(task)
-                assert isinstance(task_run, RecurringTaskRun)
-                task_runs.append(task_run)
-            else:
-                task.unlock()
+    task_run = None
+    if task.should_execute:
+        task, task_run = _run_task(task)
+        assert isinstance(task_run, RecurringTaskRun)
+    else:
+        task.unlock()
 
-        # update all tasks that were not deleted
-        to_update = [task for task in tasks if task.id]
-        RecurringTask.objects.using(database).bulk_update(
-            to_update,
-            fields=["is_locked", "locked_at"],
-        )
+    task.save(using=database, update_fields=["is_locked", "locked_at"])
 
-        if task_runs:
-            RecurringTaskRun.objects.using(database).bulk_create(task_runs)
-            logger.debug(f"Finished running {len(task_runs)} recurring task(s)")
-
-        return task_runs
+    if task_run:
+        task_run.save(using=database)
+        logger.debug("Finished running recurring task")
+        return [task_run]
 
     return []
 

--- a/src/task_processor/threads.py
+++ b/src/task_processor/threads.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.db import close_old_connections
 from django.utils import timezone
 
-from task_processor.processor import run_recurring_tasks, run_tasks
+from task_processor.processor import run_recurring_task, run_tasks
 from task_processor.task_registry import initialise
 from task_processor.types import TaskProcessorConfig
 
@@ -111,7 +111,7 @@ class TaskRunner(Thread):
 
                 # Recurring tasks are only run on one database
                 if (database == "default") ^ database_is_separate:
-                    run_recurring_tasks(database)
+                    run_recurring_task(database)
             except Exception as exception:
                 # To prevent task threads from dying if they get an error retrieving the tasks from the
                 # database this will allow the thread to continue trying to retrieve tasks if it can

--- a/tests/unit/task_processor/test_unit_task_processor_processor.py
+++ b/tests/unit/task_processor/test_unit_task_processor_processor.py
@@ -161,7 +161,7 @@ def test_run_task__timeout__kills_task(
     )
 
 
-@pytest.mark.multi_database
+@pytest.mark.multi_database(transaction=True)
 @pytest.mark.task_processor_mode
 def test_run_recurring_task__timeout__kills_task(
     caplog: pytest.LogCaptureFixture,
@@ -214,7 +214,7 @@ def test_run_recurring_task__timeout__kills_task(
     )
 
 
-@pytest.mark.multi_database
+@pytest.mark.multi_database(transaction=True)
 @pytest.mark.task_processor_mode
 def test_run_recurring_task__success__creates_recurring_task_run_object(
     current_database: str,
@@ -246,7 +246,7 @@ def test_run_recurring_task__success__creates_recurring_task_run_object(
     assert task_run.error_details is None
 
 
-@pytest.mark.multi_database
+@pytest.mark.multi_database(transaction=True)
 @pytest.mark.task_processor_mode
 def test_run_recurring_task__locked_task_after_timeout__runs_task(
     current_database: str,
@@ -375,7 +375,7 @@ def test_run_recurring_task__multiple_tasks__loops_over_all(
         )
 
 
-@pytest.mark.multi_database
+@pytest.mark.multi_database(transaction=True)
 @pytest.mark.task_processor_mode
 def test_run_recurring_task__called_before_interval__executes_only_once(
     current_database: str,
@@ -564,7 +564,7 @@ def test_run_task__failed_task__runs_again(
     assert task.is_locked is False
 
 
-@pytest.mark.multi_database
+@pytest.mark.multi_database(transaction=True)
 @pytest.mark.task_processor_mode
 def test_run_recurring_task__failure__creates_recurring_task_run_object(
     current_database: str,

--- a/tests/unit/task_processor/test_unit_task_processor_processor.py
+++ b/tests/unit/task_processor/test_unit_task_processor_processor.py
@@ -183,7 +183,7 @@ def test_run_recurring_task__timeout__kills_task(
 
     # When
     start_time = time.time()
-    task_runs = run_recurring_tasks(current_database)
+    task_run = run_recurring_tasks(current_database)
     elapsed_time = time.time() - start_time
 
     # Then - the function should return quickly (within ~2 seconds)
@@ -193,12 +193,10 @@ def test_run_recurring_task__timeout__kills_task(
         "indicating it's waiting for the worker thread to finish"
     )
 
+    assert task_run is not None
     assert (
-        len(task_runs)
-        == RecurringTaskRun.objects.using(current_database).filter(task=task).count()
-        == 1
+        RecurringTaskRun.objects.using(current_database).filter(task=task).count() == 1
     )
-    task_run = task_runs[0]
     assert task_run.result == TaskResult.FAILURE.value
     assert task_run.started_at
     assert task_run.finished_at is None
@@ -233,17 +231,15 @@ def test_run_recurring_tasks__success__creates_recurring_task_run_object(
         task_identifier="test_unit_task_processor_processor._dummy_recurring_task",
     )
     # When
-    task_runs = run_recurring_tasks(current_database)
+    task_run = run_recurring_tasks(current_database)
 
     # Then
     assert cache.get(DEFAULT_CACHE_KEY)
 
+    assert task_run is not None
     assert (
-        len(task_runs)
-        == RecurringTaskRun.objects.using(current_database).filter(task=task).count()
-        == 1
+        RecurringTaskRun.objects.using(current_database).filter(task=task).count() == 1
     )
-    task_run = task_runs[0]
     assert task_run.result == TaskResult.SUCCESS.value
     assert task_run.started_at
     assert task_run.finished_at
@@ -272,17 +268,15 @@ def test_run_recurring_tasks__locked_task_after_timeout__runs_task(
 
     # When
     assert cache.get(DEFAULT_CACHE_KEY) is None
-    task_runs = run_recurring_tasks(current_database)
+    task_run = run_recurring_tasks(current_database)
 
     # Then
     assert cache.get(DEFAULT_CACHE_KEY) == DEFAULT_CACHE_VALUE
 
+    assert task_run is not None
     assert (
-        len(task_runs)
-        == RecurringTaskRun.objects.using(current_database).filter(task=task).count()
-        == 1
+        RecurringTaskRun.objects.using(current_database).filter(task=task).count() == 1
     )
-    task_run = task_runs[0]
     assert task_run.result == TaskResult.SUCCESS.value
     assert task_run.started_at
     assert task_run.finished_at
@@ -313,33 +307,30 @@ def test_run_recurring_tasks__multiple_runs__executes_expected_times(
     )
 
     # When
-    first_task_runs = run_recurring_tasks(current_database)
+    first_task_run = run_recurring_tasks(current_database)
 
     # run the process again before the task is scheduled to run again to ensure
     # that tasks are unlocked when they are picked up by the task processor but
     # not executed.
-    no_task_runs = run_recurring_tasks(current_database)
+    no_task_run = run_recurring_tasks(current_database)
 
     time.sleep(0.3)
 
-    second_task_runs = run_recurring_tasks(current_database)
+    second_task_run = run_recurring_tasks(current_database)
 
     # Then
-    assert len(first_task_runs) == 1
-    assert len(no_task_runs) == 0
-    assert len(second_task_runs) == 1
+    assert first_task_run is not None
+    assert no_task_run is None
+    assert second_task_run is not None
 
     # we should still only have 2 organisations, despite executing the
     # `run_recurring_tasks` function 3 times.
     assert cache.get(DEFAULT_CACHE_KEY) == 2
 
-    all_task_runs = first_task_runs + second_task_runs
     assert (
-        len(all_task_runs)
-        == RecurringTaskRun.objects.using(current_database).filter(task=task).count()
-        == 2
+        RecurringTaskRun.objects.using(current_database).filter(task=task).count() == 2
     )
-    for task_run in all_task_runs:
+    for task_run in (first_task_run, second_task_run):
         assert task_run.result == TaskResult.SUCCESS.value
         assert task_run.started_at
         assert task_run.finished_at
@@ -436,10 +427,10 @@ def test_run_recurring_tasks__unregistered_new_task__does_nothing(
     registered_tasks.pop(task_identifier)
 
     # When
-    task_runs = run_recurring_tasks(current_database)
+    task_run = run_recurring_tasks(current_database)
 
     # Then
-    assert len(task_runs) == 0
+    assert task_run is None
     assert (
         RecurringTask.objects.using(current_database)
         .filter(task_identifier=task_identifier)
@@ -471,10 +462,10 @@ def test_run_recurring_tasks__unregistered_old_task__deletes_task(
     registered_tasks.pop(task_identifier)
 
     # When
-    task_runs = run_recurring_tasks(current_database)
+    task_run = run_recurring_tasks(current_database)
 
     # Then
-    assert len(task_runs) == 0
+    assert task_run is None
     assert not (
         RecurringTask.objects.using(current_database)
         .filter(task_identifier=task_identifier)
@@ -590,11 +581,11 @@ def test_run_recurring_task__failure__creates_recurring_task_run_object(
     task = RecurringTask.objects.get(task_identifier=task_identifier)
 
     # When
-    task_runs = run_recurring_tasks(current_database)
+    task_run = run_recurring_tasks(current_database)
 
     # Then
-    assert len(task_runs) == RecurringTaskRun.objects.filter(task=task).count() == 1
-    task_run = task_runs[0]
+    assert task_run is not None
+    assert RecurringTaskRun.objects.filter(task=task).count() == 1
     assert task_run.result == TaskResult.FAILURE.value
     assert task_run.started_at
     assert task_run.finished_at is None
@@ -613,6 +604,20 @@ def test_run_task__no_tasks__does_nothing(current_database: str) -> None:
     # Then
     assert result == []
     assert not TaskRun.objects.using(current_database).exists()
+
+
+@pytest.mark.multi_database
+@pytest.mark.task_processor_mode
+def test_run_recurring_tasks__no_tasks__does_nothing(current_database: str) -> None:
+    # Given - no recurring tasks
+    pass
+
+    # When
+    task_run = run_recurring_tasks(current_database)
+
+    # Then
+    assert task_run is None
+    assert not RecurringTaskRun.objects.using(current_database).exists()
 
 
 @pytest.mark.multi_database(transaction=True)

--- a/tests/unit/task_processor/test_unit_task_processor_processor.py
+++ b/tests/unit/task_processor/test_unit_task_processor_processor.py
@@ -33,7 +33,7 @@ from task_processor.models import (
 )
 from task_processor.processor import (
     UNREGISTERED_RECURRING_TASK_GRACE_PERIOD,
-    run_recurring_tasks,
+    run_recurring_task,
     run_tasks,
 )
 from task_processor.task_registry import initialise, registered_tasks
@@ -183,13 +183,13 @@ def test_run_recurring_task__timeout__kills_task(
 
     # When
     start_time = time.time()
-    task_run = run_recurring_tasks(current_database)
+    task_run = run_recurring_task(current_database)
     elapsed_time = time.time() - start_time
 
     # Then - the function should return quickly (within ~2 seconds)
     # Not block for 10 seconds waiting for the worker thread
     assert elapsed_time < 2.0, (
-        f"run_recurring_tasks blocked for {elapsed_time:.2f} seconds, "
+        f"run_recurring_task blocked for {elapsed_time:.2f} seconds, "
         "indicating it's waiting for the worker thread to finish"
     )
 
@@ -216,7 +216,7 @@ def test_run_recurring_task__timeout__kills_task(
 
 @pytest.mark.multi_database
 @pytest.mark.task_processor_mode
-def test_run_recurring_tasks__success__creates_recurring_task_run_object(
+def test_run_recurring_task__success__creates_recurring_task_run_object(
     current_database: str,
     settings: SettingsWrapper,
 ) -> None:
@@ -231,7 +231,7 @@ def test_run_recurring_tasks__success__creates_recurring_task_run_object(
         task_identifier="test_unit_task_processor_processor._dummy_recurring_task",
     )
     # When
-    task_run = run_recurring_tasks(current_database)
+    task_run = run_recurring_task(current_database)
 
     # Then
     assert cache.get(DEFAULT_CACHE_KEY)
@@ -248,7 +248,7 @@ def test_run_recurring_tasks__success__creates_recurring_task_run_object(
 
 @pytest.mark.multi_database
 @pytest.mark.task_processor_mode
-def test_run_recurring_tasks__locked_task_after_timeout__runs_task(
+def test_run_recurring_task__locked_task_after_timeout__runs_task(
     current_database: str,
     settings: SettingsWrapper,
 ) -> None:
@@ -268,7 +268,7 @@ def test_run_recurring_tasks__locked_task_after_timeout__runs_task(
 
     # When
     assert cache.get(DEFAULT_CACHE_KEY) is None
-    task_run = run_recurring_tasks(current_database)
+    task_run = run_recurring_task(current_database)
 
     # Then
     assert cache.get(DEFAULT_CACHE_KEY) == DEFAULT_CACHE_VALUE
@@ -290,7 +290,7 @@ def test_run_recurring_tasks__locked_task_after_timeout__runs_task(
 
 @pytest.mark.multi_database(transaction=True)
 @pytest.mark.task_processor_mode
-def test_run_recurring_tasks__multiple_runs__executes_expected_times(
+def test_run_recurring_task__multiple_runs__executes_expected_times(
     current_database: str,
     settings: SettingsWrapper,
 ) -> None:
@@ -307,16 +307,16 @@ def test_run_recurring_tasks__multiple_runs__executes_expected_times(
     )
 
     # When
-    first_task_run = run_recurring_tasks(current_database)
+    first_task_run = run_recurring_task(current_database)
 
     # run the process again before the task is scheduled to run again to ensure
     # that tasks are unlocked when they are picked up by the task processor but
     # not executed.
-    no_task_run = run_recurring_tasks(current_database)
+    no_task_run = run_recurring_task(current_database)
 
     time.sleep(0.3)
 
-    second_task_run = run_recurring_tasks(current_database)
+    second_task_run = run_recurring_task(current_database)
 
     # Then
     assert first_task_run is not None
@@ -324,7 +324,7 @@ def test_run_recurring_tasks__multiple_runs__executes_expected_times(
     assert second_task_run is not None
 
     # we should still only have 2 organisations, despite executing the
-    # `run_recurring_tasks` function 3 times.
+    # `run_recurring_task` function 3 times.
     assert cache.get(DEFAULT_CACHE_KEY) == 2
 
     assert (
@@ -339,7 +339,7 @@ def test_run_recurring_tasks__multiple_runs__executes_expected_times(
 
 @pytest.mark.multi_database(transaction=True)
 @pytest.mark.task_processor_mode
-def test_run_recurring_tasks__multiple_tasks__loops_over_all(
+def test_run_recurring_task__multiple_tasks__loops_over_all(
     current_database: str,
     settings: SettingsWrapper,
 ) -> None:
@@ -358,9 +358,9 @@ def test_run_recurring_tasks__multiple_tasks__loops_over_all(
 
     initialise()
 
-    # When, we call run_recurring_tasks in a loop few times
+    # When, we call run_recurring_task in a loop few times
     for _ in range(4):
-        run_recurring_tasks(current_database)
+        run_recurring_task(current_database)
 
     # Then - we should have exactly one RecurringTaskRun for each task
     for i in range(1, 4):
@@ -377,7 +377,7 @@ def test_run_recurring_tasks__multiple_tasks__loops_over_all(
 
 @pytest.mark.multi_database
 @pytest.mark.task_processor_mode
-def test_run_recurring_tasks__called_before_interval__executes_only_once(
+def test_run_recurring_task__called_before_interval__executes_only_once(
     current_database: str,
     settings: SettingsWrapper,
 ) -> None:
@@ -393,9 +393,9 @@ def test_run_recurring_tasks__called_before_interval__executes_only_once(
         task_identifier="test_unit_task_processor_processor._dummy_recurring_task",
     )
 
-    # When - we call run_recurring_tasks twice
-    run_recurring_tasks(current_database)
-    run_recurring_tasks(current_database)
+    # When - we call run_recurring_task twice
+    run_recurring_task(current_database)
+    run_recurring_task(current_database)
 
     # Then - we expect the task to have been run once
 
@@ -408,7 +408,7 @@ def test_run_recurring_tasks__called_before_interval__executes_only_once(
 
 @pytest.mark.multi_database
 @pytest.mark.task_processor_mode
-def test_run_recurring_tasks__unregistered_new_task__does_nothing(
+def test_run_recurring_task__unregistered_new_task__does_nothing(
     current_database: str,
     settings: SettingsWrapper,
 ) -> None:
@@ -427,7 +427,7 @@ def test_run_recurring_tasks__unregistered_new_task__does_nothing(
     registered_tasks.pop(task_identifier)
 
     # When
-    task_run = run_recurring_tasks(current_database)
+    task_run = run_recurring_task(current_database)
 
     # Then
     assert task_run is None
@@ -440,7 +440,7 @@ def test_run_recurring_tasks__unregistered_new_task__does_nothing(
 
 @pytest.mark.multi_database
 @pytest.mark.task_processor_mode
-def test_run_recurring_tasks__unregistered_old_task__deletes_task(
+def test_run_recurring_task__unregistered_old_task__deletes_task(
     current_database: str,
     settings: SettingsWrapper,
 ) -> None:
@@ -462,7 +462,7 @@ def test_run_recurring_tasks__unregistered_old_task__deletes_task(
     registered_tasks.pop(task_identifier)
 
     # When
-    task_run = run_recurring_tasks(current_database)
+    task_run = run_recurring_task(current_database)
 
     # Then
     assert task_run is None
@@ -581,7 +581,7 @@ def test_run_recurring_task__failure__creates_recurring_task_run_object(
     task = RecurringTask.objects.get(task_identifier=task_identifier)
 
     # When
-    task_run = run_recurring_tasks(current_database)
+    task_run = run_recurring_task(current_database)
 
     # Then
     assert task_run is not None
@@ -608,12 +608,12 @@ def test_run_task__no_tasks__does_nothing(current_database: str) -> None:
 
 @pytest.mark.multi_database
 @pytest.mark.task_processor_mode
-def test_run_recurring_tasks__no_tasks__does_nothing(current_database: str) -> None:
+def test_run_recurring_task__no_tasks__does_nothing(current_database: str) -> None:
     # Given - no recurring tasks
     pass
 
     # When
-    task_run = run_recurring_tasks(current_database)
+    task_run = run_recurring_task(current_database)
 
     # Then
     assert task_run is None
@@ -728,7 +728,7 @@ def test_run_task__backoff_recurring__raises_expected(
 
     # When / Then
     with pytest.raises(AssertionError) as exc_info:
-        run_recurring_tasks(current_database)
+        run_recurring_task(current_database)
 
     assert (
         str(exc_info.value)
@@ -823,7 +823,7 @@ def test_run_tasks__tasks_executed__expected_metrics(
 
     # When
     run_tasks(current_database, 2)
-    run_recurring_tasks(current_database)
+    run_recurring_task(current_database)
 
     # Then
     assert_metric(
@@ -993,7 +993,7 @@ def test_recurring_tasks__picked_up_but_not_executed__are_unlocked(
     )
 
     # When
-    run_recurring_tasks(current_database)
+    run_recurring_task(current_database)
 
     # Then
     recurring_task.refresh_from_db(using=current_database)

--- a/tests/unit/task_processor/test_unit_task_processor_threads.py
+++ b/tests/unit/task_processor/test_unit_task_processor_threads.py
@@ -54,7 +54,7 @@ def test_task_runner__multi_database___consumes_tasks_from_multiple_databases(
     # Given
     settings.TASK_PROCESSOR_DATABASES = ["default", "task_processor"]
     run_tasks = mocker.patch.object(threads, "run_tasks")
-    run_recurring_tasks = mocker.patch.object(threads, "run_recurring_tasks")
+    run_recurring_task = mocker.patch.object(threads, "run_recurring_task")
     task_runner = mocker.Mock()
 
     # When
@@ -65,7 +65,7 @@ def test_task_runner__multi_database___consumes_tasks_from_multiple_databases(
         mocker.call("default", task_runner.queue_pop_size),
         mocker.call("task_processor", task_runner.queue_pop_size),
     ]
-    assert run_recurring_tasks.call_args_list == [
+    assert run_recurring_task.call_args_list == [
         mocker.call("task_processor"),
     ]
 
@@ -78,7 +78,7 @@ def test_task_runner__single_database___consumes_tasks_from_one_databases(
 ) -> None:
     # Given
     run_tasks = mocker.patch.object(threads, "run_tasks")
-    run_recurring_tasks = mocker.patch.object(threads, "run_recurring_tasks")
+    run_recurring_task = mocker.patch.object(threads, "run_recurring_task")
     task_runner = mocker.Mock()
 
     # When
@@ -88,6 +88,6 @@ def test_task_runner__single_database___consumes_tasks_from_one_databases(
     assert run_tasks.call_args_list == [
         mocker.call(current_database, task_runner.queue_pop_size),
     ]
-    assert run_recurring_tasks.call_args_list == [
+    assert run_recurring_task.call_args_list == [
         mocker.call(current_database),
     ]


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to https://github.com/Flagsmith/flagsmith-common/issues/152

The SQL function backing `RecurringTaskManager` (`get_recurringtasks_to_process`) is `LIMIT 1`, so it always returns 0 or 1 rows. Despite that, `run_recurring_tasks` was structured around a loop with `bulk_create` for `RecurringTaskRun`s and `bulk_update` for the `RecurringTask` lock columns — bulk machinery operating on at most one row.

This PR:

- Replaces the loop + bulk pipeline in `run_recurring_tasks` with straight-line single-task handling: pick the one row, dispatch on `is_task_registered` / `should_execute`, then `task.save(update_fields=…)` and `task_run.save()` directly.
- Renames `RecurringTaskManager.get_tasks_to_process()` → `get_task_to_process()` and changes its return type from `RawQuerySet[RecurringTask]` to `RecurringTask | None`, so the Python contract matches the SQL.
- Leaves the underlying SQL function name (`get_recurringtasks_to_process`) untouched — it's referenced from migration history (`reverse_sql`) and renaming it would force a migration for zero functional gain.
- Preserves all existing comments verbatim and the original `if task.should_execute / else task.unlock()` control flow.

`TaskManager.get_tasks_to_process(num_tasks)` (for non-recurring `Task`s) is genuinely multi-row and is unchanged.

## How did you test this code?

- Covered by existing unit tests