### PR TITLE
fix: drop stale DB connections before recurring task save

### DIFF
--- a/src/task_processor/processor.py
+++ b/src/task_processor/processor.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from importlib.metadata import version
 
 from django.conf import settings
+from django.db import close_old_connections
 from django.utils import timezone
 from opentelemetry import context as otel_context
 from opentelemetry import propagate, trace
@@ -93,6 +94,10 @@ def run_recurring_task(database: str) -> RecurringTaskRun | None:
         task, run = _run_task(task)
         assert isinstance(run, RecurringTaskRun)
         task_run = run
+        # task.run() may have idled the DB connection past the server's
+        # session timeout; drop stale connections so the saves below open
+        # a fresh one. See Sentry FLAGSMITH-API-5EM.
+        close_old_connections()
     else:
         task.unlock()
 

--- a/tests/unit/task_processor/test_unit_task_processor_processor.py
+++ b/tests/unit/task_processor/test_unit_task_processor_processor.py
@@ -161,7 +161,7 @@ def test_run_task__timeout__kills_task(
     )
 
 
-@pytest.mark.multi_database
+@pytest.mark.multi_database(transaction=True)
 @pytest.mark.task_processor_mode
 def test_run_recurring_task__timeout__kills_task(
     caplog: pytest.LogCaptureFixture,
@@ -214,7 +214,7 @@ def test_run_recurring_task__timeout__kills_task(
     )
 
 
-@pytest.mark.multi_database
+@pytest.mark.multi_database(transaction=True)
 @pytest.mark.task_processor_mode
 def test_run_recurring_task__success__creates_recurring_task_run_object(
     current_database: str,
@@ -246,7 +246,7 @@ def test_run_recurring_task__success__creates_recurring_task_run_object(
     assert task_run.error_details is None
 
 
-@pytest.mark.multi_database
+@pytest.mark.multi_database(transaction=True)
 @pytest.mark.task_processor_mode
 def test_run_recurring_task__locked_task_after_timeout__runs_task(
     current_database: str,
@@ -375,7 +375,7 @@ def test_run_recurring_task__multiple_tasks__loops_over_all(
         )
 
 
-@pytest.mark.multi_database
+@pytest.mark.multi_database(transaction=True)
 @pytest.mark.task_processor_mode
 def test_run_recurring_task__called_before_interval__executes_only_once(
     current_database: str,
@@ -564,7 +564,7 @@ def test_run_task__failed_task__runs_again(
     assert task.is_locked is False
 
 
-@pytest.mark.multi_database
+@pytest.mark.multi_database(transaction=True)
 @pytest.mark.task_processor_mode
 def test_run_recurring_task__failure__creates_recurring_task_run_object(
     current_database: str,


### PR DESCRIPTION
## Summary

A long-running recurring task can leave the main-thread DB connection idle past the server's session timeout. RDS terminates the session, and the follow-up `task.save()` / `task_run.save()` raises `OperationalError: SSL connection has been closed unexpectedly`. Fix calls `close_old_connections()` between `_run_task()` and the saves so Django opens a fresh connection if the prior one was killed.

Same root cause, same shape of fix as flagsmith#7219.

Fixes [FLAGSMITH-API-5EM](https://flagsmith.sentry.io/issues/7104831059).  and https://github.com/Flagsmith/flagsmith/issues/7358

## Test plan

- [x] Reproduced bug locally with a real Postgres + `pg_terminate_backend`; without the fix `task.save()` raises `OperationalError`, with the fix both saves succeed.
- [x] All recurring-task unit tests pass on `[default]`. 5 tests were switched to `multi_database(transaction=True)` to dodge the pytest-django atomic / `close_old_connections` collision documented in flagsmith#7219.