### PR TITLE
fix(deps): bump urllib3 to 2.7.0 [security]

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2054,11 +2054,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.1"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/1d/0f3a93cca1ac5e8287842ed4eebbd0f7a991315089b1a0b01c7788aa7b63/urllib3-2.6.1.tar.gz", hash = "sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f", size = 432678, upload-time = "2025-12-08T15:25:26.773Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/56/190ceb8cb10511b730b564fb1e0293fa468363dbad26145c34928a60cb0c/urllib3-2.6.1-py3-none-any.whl", hash = "sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b", size = 131138, upload-time = "2025-12-08T15:25:25.51Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `urllib3` 2.6.1 → 2.7.0 in `uv.lock` to clear three open advisories:
  - [CVE-2026-21441](https://github.com/advisories/GHSA-38jv-5279-wg99) (CWE-409)
  - [CVE-2026-44432](https://github.com/advisories/GHSA-mf9v-mfxr-j63j) (CWE-409)
  - [CVE-2026-44431](https://github.com/advisories/GHSA-qccp-gfcp-xxvc) (CWE-200)
- Lockfile-only change; `pyproject.toml` untouched. `urllib3` is transitive (via `requests` / `sentry-sdk`).

## Why this is manual
Renovate's `uv` manager doesn't raise targeted security PRs for transitive dependencies — the OSV/vulnerability-alert path only covers deps declared in `pyproject.toml`. We can address future cases via `lockFileMaintenance` (broad, periodic) or by pinning the offender; see follow-up on the `ci(renovate)/only-security` branch.

## Test plan
- [x] CI passes (lint, typecheck, tests)
- [ ] Confirm GitHub Dependabot alerts for the three CVEs close on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)