### PR TITLE
fix(schemas): preserve multivariate option key in DynamoDB document

### DIFF
--- a/src/flagsmith_schemas/dynamodb.py
+++ b/src/flagsmith_schemas/dynamodb.py
@@ -48,6 +48,8 @@ class MultivariateFeatureOption(TypedDict):
     """Unique identifier for the multivariate feature option in Core. This is used by Core UI to display the selected option for an identity override for a multivariate feature."""
     value: DynamoFeatureValue
     """The feature state value that should be served when this option's parent multivariate feature state is selected by the engine."""
+    key: NotRequired[str | None]
+    """A stable, human-readable identifier for the variant. May be `None` for options created before keys were supported."""
 
 
 class MultivariateFeatureStateValue(TypedDict):

--- a/tests/integration/flagsmith_schemas/test_dynamodb.py
+++ b/tests/integration/flagsmith_schemas/test_dynamodb.py
@@ -17,6 +17,7 @@ from flagsmith_schemas.dynamodb import (
     EnvironmentV2Meta,
     EnvironmentV2MetaCompressed,
     Identity,
+    MultivariateFeatureOption,
 )
 from flagsmith_schemas.types import DateTimeStr, UUIDStr
 
@@ -1065,6 +1066,19 @@ def test_type_adapter__environment_multivariate_feature_states_percentage_alloca
             "msg": "Value error, Total `percentage_allocation` of multivariate feature state values cannot exceed 100.",
         }.items()
     )
+
+
+def test_type_adapter__multivariate_feature_option_with_key__key_preserved() -> None:
+    # Given
+    type_adapter = TypeAdapter(MultivariateFeatureOption)
+
+    # When
+    document = type_adapter.validate_python(
+        {"id": 1, "value": "control", "key": "control"}
+    )
+
+    # Then
+    assert document == {"id": Decimal("1"), "value": "control", "key": "control"}
 
 
 def test_import__no_pydantic__expected_annotations(


### PR DESCRIPTION
## Problem

When a multivariate option is created with a `key`, the key is correctly threaded into the engine model (`MultivariateFeatureOptionModel.key`) in `flagsmith` core, but it never reaches the DynamoDB environment document. Documents end up like:

```json
"multivariate_feature_option": {
  "id": 29176,
  "value": "variant_1"
}
```

— no `key`.

## Root cause

The environment document is validated against `EnvironmentCompressed` during compression (`map_environment_to_compressed_environment_document` → `TypeAdapter(EnvironmentCompressed).validate_python(...)`). The `MultivariateFeatureOption` TypedDict here only declared `id` and `value`, so Pydantic silently dropped the extra `key` key during validation.

## Fix

Add `key: NotRequired[str | None]` to the `MultivariateFeatureOption` TypedDict so it survives serialisation. Nullable + not-required keeps backward compatibility with documents written before keys existed.

## Testing

- Added a regression test asserting `key` is preserved through `TypeAdapter(MultivariateFeatureOption).validate_python(...)`.
- The originating bug is also covered by a failing test in `flagsmith` core (`test_map_environment_to_compressed_environment_document__mv_option_with_key__key_preserved`), which will pass once this is released and the dependency bumped.