### PR TITLE
fix: close database connections after threaded tasks

### DIFF
--- a/src/task_processor/decorators.py
+++ b/src/task_processor/decorators.py
@@ -4,6 +4,7 @@ from datetime import datetime, time, timedelta
 from threading import Thread
 
 from django.conf import settings
+from django.db import connections
 from django.db.transaction import on_commit
 from django.utils import timezone
 from opentelemetry import propagate
@@ -121,7 +122,14 @@ class TaskHandler(typing.Generic[TaskParameters]):
     ) -> None:
         kwargs = kwargs or {}
         _validate_inputs(*args, **kwargs)
-        thread = Thread(target=self.unwrapped, args=args, kwargs=kwargs, daemon=True)
+
+        def _run() -> None:
+            try:
+                self.unwrapped(*args, **kwargs)
+            finally:
+                connections.close_all()
+
+        thread = Thread(target=_run, daemon=True)
 
         def _start() -> None:
             logger.info(

--- a/tests/unit/task_processor/test_unit_task_processor_decorators.py
+++ b/tests/unit/task_processor/test_unit_task_processor_decorators.py
@@ -55,9 +55,9 @@ def test_register_task_handler_run_in_thread__transaction_commit_true__default(
         my_function.run_in_thread(args=args, kwargs=kwargs)
 
     # Then
-    mock_thread_class.assert_called_once_with(
-        target=my_function.unwrapped, args=args, kwargs=kwargs, daemon=True
-    )
+    mock_thread_class.assert_called_once()
+    assert mock_thread_class.call_args.kwargs["target"] is not my_function.unwrapped
+    assert mock_thread_class.call_args.kwargs["daemon"] is True
     mock_thread.start.assert_called_once()
 
     assert len(caplog.records) == 1
@@ -87,9 +87,9 @@ def test_register_task_handler_run_in_thread__transaction_commit__false(
     my_function.run_in_thread(args=args, kwargs=kwargs)
 
     # Then
-    mock_thread_class.assert_called_once_with(
-        target=my_function.unwrapped, args=args, kwargs=kwargs, daemon=True
-    )
+    mock_thread_class.assert_called_once()
+    assert mock_thread_class.call_args.kwargs["target"] is not my_function.unwrapped
+    assert mock_thread_class.call_args.kwargs["daemon"] is True
     mock_thread.start.assert_called_once()
 
     assert len(caplog.records) == 1
@@ -97,6 +97,40 @@ def test_register_task_handler_run_in_thread__transaction_commit__false(
         caplog.records[0].getMessage()
         == "Running function my_function in unmanaged thread."
     )
+
+
+@pytest.mark.parametrize("raises", [False, True])
+def test_register_task_handler_run_in_thread__callable_returns_or_raises__closes_database_connections(
+    mocker: MockerFixture,
+    mock_thread_class: MagicMock,
+    raises: bool,
+) -> None:
+    # Given
+    close_all = mocker.patch("task_processor.decorators.connections.close_all")
+    calls: list[tuple[str, str]] = []
+
+    @register_task_handler(
+        task_name=f"test_run_in_thread_cleanup_{raises}",
+        transaction_on_commit=False,
+    )
+    def my_function(arg: str, *, keyword_arg: str) -> None:
+        calls.append((arg, keyword_arg))
+        if raises:
+            raise RuntimeError("task failed")
+
+    # When
+    my_function.run_in_thread(args=("positional",), kwargs={"keyword_arg": "keyword"})
+    thread_target = mock_thread_class.call_args.kwargs["target"]
+
+    if raises:
+        with pytest.raises(RuntimeError, match="task failed"):
+            thread_target()
+    else:
+        thread_target()
+
+    # Then
+    assert calls == [("positional", "keyword")]
+    close_all.assert_called_once_with()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

- run unmanaged task callables through a cleanup wrapper
- close every Django database connection owned by the one-shot thread in `finally`
- preserve positional and keyword argument forwarding
- cover cleanup after both successful and failed callables

## Problem

`TaskHandler.run_in_thread()` creates a one-shot thread outside Django's request-response lifecycle. If the callable accesses the ORM, the thread-local database connection can remain idle after the thread exits. Repeated calls can therefore exhaust PostgreSQL's connection limit.

`connections.close_all()` is used instead of `close_old_connections()` because a connection opened by a short-lived thread may still be younger than `CONN_MAX_AGE`, even though the terminated thread can never reuse it.

Closes #264.

## Test plan

- `uv run --all-extras pytest tests/unit/task_processor/test_unit_task_processor_decorators.py`
- `uv run --all-extras pre-commit run --files src/task_processor/decorators.py tests/unit/task_processor/test_unit_task_processor_decorators.py`
